### PR TITLE
Fixes #136 - Allow customization of post metadata

### DIFF
--- a/layouts/partials/components/post-meta.html
+++ b/layouts/partials/components/post-meta.html
@@ -86,4 +86,5 @@
             <span class="post-meta-item busuanzi-page-pv" id="busuanzi_container_page_pv">{{ $icon }}&nbsp;<span id="busuanzi_value_page_pv"></span></span>
         {{ end }}
     {{ end }}
+    {{ partial "custom/post-meta.html" $Deliver }}
 </div>


### PR DESCRIPTION
The custom template only needs the page itself as context, it can read out `.isHome` itself if necessary - this makes things simpler.