### PR TITLE
Simpler generation of relative URLs for MS tiles

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -85,13 +85,10 @@
     {{- $safariMaskIcon := "icons/safari-pinned-tab.svg" -}}
     {{- $safariMaskColor := .Site.Params.safariMaskColor -}}
     {{- $appleTouchIcon := "icons/apple-touch-icon.png" -}}
-    {{- partial "utils/relative-url.html" (dict "Deliver" . "filename" "") -}}
-    {{- $url := .Scratch.Get "url" -}}
-    {{- $msApplicationStartURL := $url -}}
-    {{- $msApplicationTileColor := .Site.Params.msApplicationTileColor -}}
-    {{- partial "utils/relative-url.html" (dict "Deliver" . "filename" "icons/mstile-150x150.png") -}}
-    {{- $url := .Scratch.Get "url" -}}
-    {{- $msApplicationTileImage := $url -}}
+    {{- $baseUrl := (urls.Parse .Site.BaseURL).Path -}}
+    {{- if not (strings.HasSuffix $baseUrl "/") -}}
+        {{- $baseUrl = (printf "%s%s" $baseUrl "/") -}}
+    {{- end -}}
     {{- $manifest := "manifest.json" -}}
     <link rel="shortcut icon" href="{{ $favicon | relURL }}" type="image/x-icon" />
     <link rel="mask-icon" href="{{ $safariMaskIcon | relURL }}" color="{{ $safariMaskColor }}" />
@@ -101,9 +98,9 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="application-name" content="{{ .Site.Title }}" />
-    <meta name="msapplication-starturl" content="{{ $msApplicationStartURL }}" />
-    <meta name="msapplication-TileColor" content="{{ $msApplicationTileColor }}" />
-    <meta name="msapplication-TileImage" content="{{ $msApplicationTileImage }}" />
+    <meta name="msapplication-starturl" content="{{ $baseUrl }}" />
+    <meta name="msapplication-TileColor" content="{{ .Site.Params.msApplicationTileColor }}" />
+    <meta name="msapplication-TileImage" content="{{ $baseUrl }}icons/mstile-150x150.png" />
     <link rel="manifest" href="{{ $manifest | relURL }}" />
 
     <!-- Atom / RSS -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -94,9 +94,9 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="application-name" content="{{ .Site.Title }}" />
-    <meta name="msapplication-starturl" content="{{ "/" | relURL }}" />
+    <meta name="msapplication-starturl" content="{{ (.Site.GetPage "/").RelPermalink }}" />
     <meta name="msapplication-TileColor" content="{{ .Site.Params.msApplicationTileColor }}" />
-    <meta name="msapplication-TileImage" content="{{ "icons/mstile-150x150.png" | relURL }}" />
+    <meta name="msapplication-TileImage" content="{{ (.Site.GetPage "/").RelPermalink }}icons/mstile-150x150.png" />
     <link rel="manifest" href="{{ $manifest | relURL }}" />
 
     <!-- Atom / RSS -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -85,10 +85,6 @@
     {{- $safariMaskIcon := "icons/safari-pinned-tab.svg" -}}
     {{- $safariMaskColor := .Site.Params.safariMaskColor -}}
     {{- $appleTouchIcon := "icons/apple-touch-icon.png" -}}
-    {{- $baseUrl := (urls.Parse .Site.BaseURL).Path -}}
-    {{- if not (strings.HasSuffix $baseUrl "/") -}}
-        {{- $baseUrl = (printf "%s%s" $baseUrl "/") -}}
-    {{- end -}}
     {{- $manifest := "manifest.json" -}}
     <link rel="shortcut icon" href="{{ $favicon | relURL }}" type="image/x-icon" />
     <link rel="mask-icon" href="{{ $safariMaskIcon | relURL }}" color="{{ $safariMaskColor }}" />
@@ -98,9 +94,9 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="application-name" content="{{ .Site.Title }}" />
-    <meta name="msapplication-starturl" content="{{ $baseUrl }}" />
+    <meta name="msapplication-starturl" content="{{ "/" | relURL }}" />
     <meta name="msapplication-TileColor" content="{{ .Site.Params.msApplicationTileColor }}" />
-    <meta name="msapplication-TileImage" content="{{ $baseUrl }}icons/mstile-150x150.png" />
+    <meta name="msapplication-TileImage" content="{{ "icons/mstile-150x150.png" | relURL }}" />
     <link rel="manifest" href="{{ $manifest | relURL }}" />
 
     <!-- Atom / RSS -->


### PR DESCRIPTION
The theme generates some rather ugly URLs for `msapplication-starturl` and `msapplication-TileImage` meta tags. Root-relative URLs work as well and are much simpler to deduce from `.Site.BaseURL`.

Note that the same approach should work in `service-worker.html`, rendering `relative-url.html` obsolete. I didn't change it merely because I cannot test this functionality.