### PR TITLE
Allow extending header

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -71,7 +71,7 @@
                                 {{ $.Scratch.Set "year" .Key }}
                             {{ end }}
                             {{ $year := $.Scratch.Get "year" }}
-                            <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ partial "utils/icon.html" (dict "Deliver" . "name" $zodiacName "class" "chinese-zodiac") }}{{ end }}</h2>
+                            <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ partial "utils/icon.html" (dict "Deliver" $ "name" $zodiacName "class" "chinese-zodiac") }}{{ end }}</h2>
                             {{ if $.Site.Params.groupByMonth }}
                                 {{ range .Pages.GroupByDate "January" }}
                                     {{ $.Scratch.Delete "month" }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -71,7 +71,7 @@
                                 {{ $.Scratch.Set "year" .Key }}
                             {{ end }}
                             {{ $year := $.Scratch.Get "year" }}
-                            <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ replace (index $.Site.Data.SVG $zodiacName) "icon" "icon chinese-zodiac" | safeHTML }}{{ end }}</h2>
+                            <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ partial "utils/icon.html" (dict "Deliver" . "name" $zodiacName "class" "chinese-zodiac") }}{{ end }}</h2>
                             {{ if $.Site.Params.groupByMonth }}
                                 {{ range .Pages.GroupByDate "January" }}
                                     {{ $.Scratch.Delete "month" }}

--- a/layouts/index.sectionsatom.xml
+++ b/layouts/index.sectionsatom.xml
@@ -55,8 +55,7 @@
             {{ with $author.copyright -}}
                 <rights>{{ . | plainify }}</rights>
             {{- end }}
-            {{- partial "utils/summary.html" $page -}}
-            {{- $summary := .Description | default ($page.Scratch.Get "summary") -}}
+            {{- $summary := .Description | default (partial "utils/summary.html" $page) -}}
             <summary type="html">{{ $summary | html }}</summary>
             {{ if $.Site.Params.includeContent }}
                 <content type="html">{{ .Content | html }}</content>

--- a/layouts/index.sectionsatom.xml
+++ b/layouts/index.sectionsatom.xml
@@ -1,4 +1,4 @@
-{{- printf `<?xml version="1.0" encoding="utf-8"?>` | safeHTML }}
+{{ `<?xml version="1.0" encoding="utf-8"?>` | safeHTML }}
 <!-- Reference: https://tools.ietf.org/html/rfc4287 -->
 <!-- Reference: https://github.com/kaushalmodi/hugo-atom-feed/blob/master/layouts/_default/list.atom.xml -->
 <!-- Reference: https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/rss.xml -->
@@ -10,11 +10,11 @@
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ .Site.LanguageCode }}">
     <title type="text">{{ .Site.Title }}</title>
     <subtitle type="html">{{ .Site.Params.siteDescription }}</subtitle>
-    <updated>{{ now.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
+    <updated>{{ now.Format "2006-01-02T15:04:05-07:00" }}</updated>
     <id>{{ .Permalink }}</id>
     <link rel="alternate" type="text/html" href="{{ .Permalink }}" />
     {{ with .OutputFormats.Get "SectionsAtom" -}}
-        {{ printf `<link rel="self" type="%s" href="%s" />` .MediaType .Permalink | safeHTML }}
+        <link rel="self" type="{{ .MediaType }}" href="{{ .Permalink }}" />
     {{ end -}}
     {{ with .Site.Author.name -}}
         <author>
@@ -37,8 +37,8 @@
             <title type="text">{{ .Title }}</title>
             <link rel="alternate" type="text/html" href="{{ .Permalink }}" />
             <id>{{ .Permalink }}</id>
-            <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</updated>
-            <published>{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" | safeHTML }}</published>
+            <updated>{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}</updated>
+            <published>{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }}</published>
             {{ with $author -}}
                 <author>
                     {{ with .name -}}
@@ -57,9 +57,9 @@
             {{- end }}
             {{- partial "utils/summary.html" $page -}}
             {{- $summary := .Description | default ($page.Scratch.Get "summary") -}}
-            {{ printf `<summary type="html"><![CDATA[%s]]></summary>` $summary | safeHTML }}
+            <summary type="html">{{ $summary | html }}</summary>
             {{ if $.Site.Params.includeContent }}
-                {{ printf `<content type="html"><![CDATA[%s]]></content>` .Content | safeHTML }}
+                <content type="html">{{ .Content | html }}</content>
             {{ end }}
             <!-- Sections -->
             {{ if eq $.Site.Params.categoryBy "sections" }}

--- a/layouts/index.sectionsrss.xml
+++ b/layouts/index.sectionsrss.xml
@@ -50,8 +50,7 @@
                 {{ if $.Site.Params.includeContent }}
                     <description>{{ .Content | html }}</description>
                 {{ else }}
-                    {{- partial "utils/summary.html" $page -}}
-                    {{- $summary := .Description | default ($page.Scratch.Get "summary") -}}
+                    {{- $summary := .Description | default (partial "utils/summary.html" $page) -}}
                     <description>{{ $summary | html }}</description>
                 {{ end }}
                 <!-- Sections -->

--- a/layouts/index.sectionsrss.xml
+++ b/layouts/index.sectionsrss.xml
@@ -1,4 +1,4 @@
-{{- printf `<?xml version="1.0" encoding="utf-8"?>` | safeHTML }}
+{{- `<?xml version="1.0" encoding="utf-8"?>` | safeHTML }}
 <!-- Reference: https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/_default/rss.xml -->
 <!-- Reference: https://github.com/kaushalmodi/hugo-atom-feed/blob/master/layouts/_default/list.atom.xml -->
 <!-- Reference: https://validator.w3.org/feed/docs/rss2.html -->
@@ -28,9 +28,9 @@
         {{ with .Site.Copyright }}
             <copyright>{{ . | plainify }}</copyright>
         {{ end }}
-        <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+        <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
         {{ with .OutputFormats.Get "SectionsRSS" }}
-            {{ printf `<atom:link rel="self" type=%q href=%q />` .MediaType .Permalink | safeHTML }}
+            <atom:link rel="self" type="{{ .MediaType }}" href="{{ .Permalink }}" />
         {{ end }}
         {{ range (where $pages "Section" "in" .Site.Params.mainSections) }}
             {{ $page := . }}
@@ -40,7 +40,7 @@
                 <title>{{ .Title }}</title>
                 <link>{{ .Permalink }}</link>
                 <guid isPermaLink="true">{{ .Permalink }}</guid>
-                <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+                <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</pubDate>
                 {{ with $author.email }}
                     <author>{{ . }}{{ with $author.name }} ({{ . }}){{ end }}</author>
                 {{ end }}
@@ -48,11 +48,11 @@
                     <copyright>{{ . | plainify }}</copyright>
                 {{- end }}
                 {{ if $.Site.Params.includeContent }}
-                    {{ printf `<description><![CDATA[%s]]></description>` .Content | safeHTML }}
+                    <description>{{ .Content | html }}</description>
                 {{ else }}
                     {{- partial "utils/summary.html" $page -}}
                     {{- $summary := .Description | default ($page.Scratch.Get "summary") -}}
-                    {{ printf `<description><![CDATA[%s]]></description>` $summary | safeHTML }}
+                    <description>{{ $summary | html }}</description>
                 {{ end }}
                 <!-- Sections -->
                 {{ if eq $.Site.Params.categoryBy "sections" }}

--- a/layouts/partials/components/back-to-top.html
+++ b/layouts/partials/components/back-to-top.html
@@ -1,5 +1,5 @@
 {{ if or (and .IsHome .Site.Params.displayBackToTopInHome) (and (not .IsHome) .Site.Params.enableBackToTop) }}
     <div id="back-to-top" class="back-to-top">
-        <a href="#">{{ index .Site.Data.SVG .Site.Params.backToTopIcon | safeHTML }}</a>
+        <a href="#">{{ partial "utils/icon.html" (dict "Deliver" . "name" .Site.Params.backToTopIcon) }}</a>
     </div>
 {{ end }}

--- a/layouts/partials/components/minimal-footer-about.html
+++ b/layouts/partials/components/minimal-footer-about.html
@@ -3,29 +3,21 @@
         <footer class="minimal-footer-about">
             {{ with $.Site.Menus.socials }}
                 <div class="about-socials">
-                    {{ $length := sub (len .) 1 }}
                     {{ range $index, $value := . }}
                         {{- $linkType := (string .Pre) -}}
                         {{- $iconName := (string .Post) -}}
                         {{- $icon := (index $.Site.Data.SVG $iconName) -}}
-                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ replace $icon "icon" (printf `icon %s` .Identifier) | safeHTML }}{{ .Name }}</a>
-                        {{- if lt $index $length -}}
-                            {{- print " " -}}
-                        {{- end -}}
+                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{ end }}
                 </div>
             {{ end }}
             {{ with $.Site.Menus.links }}
                 <div class="about-links">
-                    {{ $length := sub (len .) 1 }}
                     {{ range $index, $value := . }}
                         {{- $linkType := (string .Pre) -}}
                         {{- $iconName := (string .Post) -}}
                         {{- $icon := (index $.Site.Data.SVG $iconName) -}}
-                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ replace $icon "icon" (printf `icon %s` .Identifier) | safeHTML }}{{ .Name }}</a>
-                        {{- if lt $index $length -}}
-                            {{- print " " -}}
-                        {{- end -}}
+                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{ end }}
                 </div>
             {{ end }}

--- a/layouts/partials/components/minimal-footer.html
+++ b/layouts/partials/components/minimal-footer.html
@@ -1,16 +1,13 @@
 {{ if and .Site.Params.enableMinimalFooter (in .Site.Params.mainSections .Section) }}
     <footer class="minimal-footer">
         {{ with .Params.tags }}
-            {{ $length := sub (len .) 1 }}
             <div class="post-tag">
                 {{- range $index, $tag := . -}}
-                    {{- $url := urls.Parse ($tag | urlize) -}}
-                    {{- $path := $url.Path -}}
-                    {{- with $.Site.GetPage (printf `/tags/%s` $path) -}}
-                        <a href="{{ .RelPermalink }}" rel="tag" class="post-tag-link">#{{ .Slug | default .LinkTitle | default $tag | lower | anchorize }}</a>
-                        {{- if lt $index $length -}}
-                            {{- print " " -}}
+                    {{- with $.Site.GetPage (printf `/tags/%s` ($tag | urlize)) -}}
+                        {{- if gt $index 0 -}}
+                            {{- " " -}}
                         {{- end -}}
+                        <a href="{{ .RelPermalink }}" rel="tag" class="post-tag-link">#{{ .Slug | default .LinkTitle | default $tag | lower | anchorize }}</a>
                     {{- end -}}
                 {{- end -}}
             </div>
@@ -21,48 +18,32 @@
                     {{- with .Site.GetPage .Section -}}
                         <a href="{{ .RelPermalink }}" class="post-category-link active">{{ .Slug | default .Params.url | default .LinkTitle | default $.Section | lower | anchorize }}</a>
                     {{- end -}}
-                    {{- if gt (len .Site.Params.mainSections) 1 -}}
-                        {{- printf `%s` " | " | safeHTML -}}
-                        {{- $sections := (.Site.Params.mainSections | symdiff (slice .Section)) -}}
-                        {{- $length := sub (len $sections) 1 -}}
-                        {{- range $index, $section := $sections -}}
-                            {{- with $.Site.GetPage $section -}}
-                                <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .Params.url | default .LinkTitle | default $section | lower | anchorize }}</a>
-                                {{- if lt $index $length -}}
-                                    {{- printf `%s` " | " | safeHTML -}}
-                                {{- end -}}
-                            {{- end -}}
+                    {{- $sections := .Site.Params.mainSections | symdiff (slice .Section) -}}
+                    {{- range $index, $section := $sections -}}
+                        {{- " | " -}}
+                        {{- with $.Site.GetPage $section -}}
+                            <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .Params.url | default .LinkTitle | default $section | lower | anchorize }}</a>
                         {{- end -}}
                     {{- end -}}
                 {{ else }}
-                    {{ $sections := split (strings.TrimSuffix "/" ($.File.Dir | default $.Section)) "/" }}
-                    {{ with $sections }}
-                        {{ $.Scratch.Delete "sectionsDirMeta" }}
-                        {{ $.Scratch.Delete "sectionsMeta" }}
-                        {{ $.Scratch.Set "index" 0 }}
-                        {{ range $sections }}
-                            {{ $section := . }}
-                            {{ $.Scratch.Add "sectionsDirMeta" (printf `/%s` $section) }}
-                            {{ with $.Site.GetPage ($.Scratch.Get "sectionsDirMeta") }}
+                    {{ $pathParts := split (strings.TrimSuffix "/" ($.File.Dir | default $.Section)) "/" }}
+                    {{ $sections := dict }}
+                    {{ with $pathParts }}
+                        {{ range $index, $section := $pathParts }}
+                            {{ with $.Site.GetPage (printf `/%s` $section) }}
                                 {{ if (eq .Kind "section") }}
-                                    {{ $.Scratch.SetInMap "sectionsMeta" (printf `%s/%s` (string ($.Scratch.Get "index")) .RelPermalink) (.Slug | default .Params.url | default .LinkTitle | default $section | lower | anchorize) }}
-                                    {{ $.Scratch.Set "index" (add ($.Scratch.Get "index") 1) }}
+                                    {{ $sections = merge $sections (dict (printf `%s/%s` (string $index) .RelPermalink) (.Slug | default .Params.url | default .LinkTitle | default $section | lower | anchorize)) }}
                                 {{ end }}
                             {{ end }}
                         {{ end }}
                     {{ end }}
-                    {{ $sections := .Scratch.Get "sectionsMeta" }}
                     {{ with $sections }}
-                        {{ $length := (sub (len $sections) 1) }}
                         {{- range $link, $title := $sections -}}
                             {{- $index := $link | replaceRE `(\d+)/.+` `$1` | int -}}
-                            {{- if lt $index $length -}}
-                                {{- $.Scratch.Set "delimiter" ($.Site.Params.categoryDelimiter | default "/") -}}
-                            {{- else -}}
-                                {{- $.Scratch.Set "delimiter" "" -}}
+                            {{- if gt $index 0 -}}
+                                {{- $.Site.Params.categoryDelimiter | default "/" -}}
                             {{- end -}}
-                            {{- $delimiter := ($.Scratch.Get "delimiter") -}}
-                            {{- printf `<a href="%s" class="post-category-link">%s</a>%s` ($link | replaceRE `\d+/(.+)` `$1`) ($title | lower) $delimiter | safeHTML -}}
+                            <a href="{{ $link | replaceRE `\d+/(.+)` `$1` }}" class="post-category-link">{{ $title | lower }}</a>
                         {{- end -}}
                     {{ end }}
                 {{ end }}
@@ -72,48 +53,31 @@
             {{ with .Params.categories }}
                 <div class="post-category">
                     {{ if $.Site.Params.enableVerticalBarStructure }}
-                        {{- $currentTopLevelCategory := (delimit (first 1 .) " ") -}}
-                        {{- $url := urls.Parse ($currentTopLevelCategory | urlize) -}}
-                        {{- $path := $url.Path -}}
-                        {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
-                            <a href="{{ .RelPermalink }}" class="post-category-link active">{{ .Slug | default .LinkTitle | default $path | lower | anchorize }}</a>
+                        {{- $currentTopLevelCategory := (index . 0) -}}
+                        {{- with $.Site.GetPage (printf `/categories/%s` ($currentTopLevelCategory | urlize)) -}}
+                            <a href="{{ .RelPermalink }}" class="post-category-link active">{{ .Slug | default .LinkTitle | default $currentTopLevelCategory | lower | anchorize }}</a>
                         {{- end -}}
-                        {{- $.Scratch.Delete "topLevelCategories" -}}
+                        {{- $categories := slice -}}
                         {{- range $.Site.RegularPages -}}
                             {{- with .Param "categories" -}}
-                                {{- $topLevelCategory := ((delimit (first 1 .) " ") | urlize) -}}
-                                {{- $.Scratch.Add "topLevelCategories" (slice $topLevelCategory) -}}
+                                {{- $topLevelCategory := (index . 0 | urlize) -}}
+                                {{- $categories = union $categories (slice $topLevelCategory) -}}
                             {{- end -}}
                         {{- end -}}
-                        {{- $categories := uniq ($.Scratch.Get "topLevelCategories") -}}
-                        {{- if gt (len $categories) 1 -}}
-                            {{- printf `%s` " | " | safeHTML -}}
-                            {{- $categories := ($categories | symdiff (slice ($currentTopLevelCategory | urlize))) -}}
-                            {{- $length := sub (len $categories) 1 -}}
-                            {{- range $index, $category := $categories -}}
-                                {{- $category := urls.Parse $category -}}
-                                {{- $path := $category.Path -}}
-                                {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
-                                    <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .LinkTitle | default $path | lower | anchorize }}</a>
-                                    {{- if lt $index $length -}}
-                                        {{- printf `%s` " | " | safeHTML -}}
-                                    {{- end -}}
-                                {{- end -}}
+                        {{- $categories = uniq $categories | symdiff (slice $currentTopLevelCategory) -}}
+                        {{- range $index, $category := $categories -}}
+                            {{- " | " -}}
+                            {{- with $.Site.GetPage (printf `/categories/%s` $category) -}}
+                                <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .LinkTitle | default $category | lower | anchorize }}</a>
                             {{- end -}}
                         {{- end -}}
                     {{ else }}
-                        {{ $length := sub (len .) 1 }}
                         {{- range $index, $category := . -}}
-                            {{- if lt $index $length -}}
-                                {{- $.Scratch.Set "delimiter" ($.Site.Params.categoryDelimiter | default "/") -}}
-                            {{- else -}}
-                                {{- $.Scratch.Set "delimiter" "" -}}
+                            {{- if gt $index 0 -}}
+                                {{- $.Site.Params.categoryDelimiter | default "/" -}}
                             {{- end -}}
-                            {{- $delimiter := ($.Scratch.Get "delimiter") -}}
-                            {{- $url := urls.Parse ($category | urlize) -}}
-                            {{- $path := $url.Path -}}
-                            {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
-                                {{- printf `<a href="%s" class="post-category-link">%s</a>%s` .RelPermalink (.Slug | default .LinkTitle | default $category | lower | anchorize) $delimiter | safeHTML -}}
+                            {{- with $.Site.GetPage (printf `/categories/%s` ($category | urlize )) -}}
+                                <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .LinkTitle | default $category | lower | anchorize }}</a>
                             {{- end -}}
                         {{- end -}}
                     {{ end }}

--- a/layouts/partials/components/minimal-footer.html
+++ b/layouts/partials/components/minimal-footer.html
@@ -3,11 +3,13 @@
         {{ with .Params.tags }}
             <div class="post-tag">
                 {{- range $index, $tag := . -}}
-                    {{- with $.Site.GetPage (printf `/tags/%s` ($tag | urlize)) -}}
+                    <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
+                    {{- $path := (urls.Parse ($tag | urlize)).Path -}}
+                    {{- with $.Site.GetPage (printf `/tags/%s` $path) -}}
                         {{- if gt $index 0 -}}
                             {{- " " -}}
                         {{- end -}}
-                        <a href="{{ .RelPermalink }}" rel="tag" class="post-tag-link">#{{ .Slug | default .LinkTitle | default $tag | lower | anchorize }}</a>
+                        <a href="{{ .RelPermalink }}" rel="tag" class="post-tag-link">#{{ .Slug | default .LinkTitle | default $path | lower | anchorize }}</a>
                     {{- end -}}
                 {{- end -}}
             </div>
@@ -54,21 +56,25 @@
                 <div class="post-category">
                     {{ if $.Site.Params.enableVerticalBarStructure }}
                         {{- $currentTopLevelCategory := (index . 0) -}}
-                        {{- with $.Site.GetPage (printf `/categories/%s` ($currentTopLevelCategory | urlize)) -}}
-                            <a href="{{ .RelPermalink }}" class="post-category-link active">{{ .Slug | default .LinkTitle | default $currentTopLevelCategory | lower | anchorize }}</a>
+                        <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
+                        {{- $path := (urls.Parse ($currentTopLevelCategory | urlize)).Path -}}
+                        {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
+                            <a href="{{ .RelPermalink }}" class="post-category-link active">{{ .Slug | default .LinkTitle | default $path | lower | anchorize }}</a>
                         {{- end -}}
                         {{- $categories := slice -}}
                         {{- range $.Site.RegularPages -}}
                             {{- with .Param "categories" -}}
-                                {{- $topLevelCategory := (index . 0 | urlize) -}}
+                                {{- $topLevelCategory := (index . 0) -}}
                                 {{- $categories = union $categories (slice $topLevelCategory) -}}
                             {{- end -}}
                         {{- end -}}
                         {{- $categories = uniq $categories | symdiff (slice $currentTopLevelCategory) -}}
                         {{- range $index, $category := $categories -}}
                             {{- " | " -}}
-                            {{- with $.Site.GetPage (printf `/categories/%s` $category) -}}
-                                <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .LinkTitle | default $category | lower | anchorize }}</a>
+                            <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
+                            {{- $path := (urls.Parse ($category | urlize)).Path -}}
+                            {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
+                                <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .LinkTitle | default $path | lower | anchorize }}</a>
                             {{- end -}}
                         {{- end -}}
                     {{ else }}
@@ -76,8 +82,10 @@
                             {{- if gt $index 0 -}}
                                 {{- $.Site.Params.categoryDelimiter | default "/" -}}
                             {{- end -}}
-                            {{- with $.Site.GetPage (printf `/categories/%s` ($category | urlize )) -}}
-                                <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .LinkTitle | default $category | lower | anchorize }}</a>
+                            <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
+                            {{- $path := (urls.Parse ($category | urlize)).Path -}}
+                            {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
+                                <a href="{{ .RelPermalink }}" class="post-category-link">{{ .Slug | default .LinkTitle | default $path | lower | anchorize }}</a>
                             {{- end -}}
                         {{- end -}}
                     {{ end }}

--- a/layouts/partials/components/post-copyright.html
+++ b/layouts/partials/components/post-copyright.html
@@ -6,9 +6,9 @@
         <ul class="post-copyright">
             <li class="copyright-item author">
                 {{- with $author.website -}}
-                    {{ printf `<span class="copyright-item-text">%s</span>%s<a href="%s" target="_blank" rel="noopener">%s</a>` (i18n "copyrightAuthor") (i18n "colon") . $author.name | safeHTML }}
+                    <span class="copyright-item-text">{{ i18n "copyrightAuthor" }}</span>{{ i18n "colon" }}<a href="{{ . }}" target="_blank" rel="noopener">{{ $author.name }}</a>
                 {{- else -}}
-                    {{ printf `<span class="copyright-item-text">%s</span>%s%s` (i18n "copyrightAuthor") (i18n "colon") $author.name | safeHTML }}
+                    <span class="copyright-item-text">{{ i18n "copyrightAuthor" }}</span>{{ i18n "colon" }}{{ $author.name }}
                 {{- end -}}
             </li>
             {{ if $.Params.original | default $.Site.Params.original }}
@@ -16,17 +16,17 @@
                 {{ $decodedPath := $url.Path }}
                 {{ $baseURLWithLangFix := (strings.TrimSuffix "/" (print `/` | absLangURL)) }}
                 {{ $decodedPermalink := (printf `%s%s` $baseURLWithLangFix $decodedPath) }}
-                <li class="copyright-item link">{{ printf `<span class="copyright-item-text">%s</span>%s<a href="%s" target="_blank" rel="noopener">%s</a>` (i18n "copyrightLink") (i18n "colon") $.RelPermalink $decodedPermalink | safeHTML }}</li>
+                <li class="copyright-item link"><span class="copyright-item-text">{{ i18n "copyrightLink" }}</span>{{ i18n "colon" }}<a href="{{ $.RelPermalink }}" target="_blank" rel="noopener">{{ $decodedPermalink }}</a></li>
             {{ else }}
                 {{ with $.Params.link }}
-                    <li class="copyright-item link">{{ printf `<span class="copyright-item-text">%s</span>%s<a href="%s" target="_blank" rel="noopener">%s</a>` (i18n "copyrightLink") (i18n "colon") . . | safeHTML }}</li>
+                    <li class="copyright-item link"><span class="copyright-item-text">{{ i18n "copyrightLink" }}</span>{{ i18n "colon" }}<a href="{{ . }}" target="_blank" rel="noopener">{{ . }}</a></li>
                 {{ end }}
             {{ end }}
             {{ with $author.copyright }}
                 {{- $raw := . -}}
                 {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
                 {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                <li class="copyright-item license">{{ printf `<span class="copyright-item-text">%s</span>%s%s` (i18n "copyrightLicense") (i18n "colon") $Content | safeHTML }}</li>
+                <li class="copyright-item license"><span class="copyright-item-text">{{ i18n "copyrightLicense" }}</span>{{ i18n "colon" }}{{ $Content }}</li>
             {{ end }}
         </ul>
     {{ end }}

--- a/layouts/partials/components/post-gitinfo.html
+++ b/layouts/partials/components/post-gitinfo.html
@@ -4,22 +4,24 @@
             {{ if or .Site.Params.displayCommitHash .Site.Params.displayCommitMessage }}
                 <div class="post-gitinfo-left">
                     {{ if .Site.Params.displayCommitHash }}
-                        {{ $icon := (replace (index .Site.Data.SVG .Site.Params.gitIcon) "icon" "icon git-icon") }}
                         <div class="gitinfo-item commit">
                             {{- with .Site.Params.repoURL -}}
-                                {{- $commit := (printf `<a href="%s/commit/%s" target="_blank" rel="noopener">%s%s</a>` . $.GitInfo.Hash $icon $.GitInfo.AbbreviatedHash) -}}
-                                {{- $.Scratch.Set "commit" $commit -}}
+                                <a href="{{ . }}/commit/{{ $.GitInfo.Hash }}" target="_blank" rel="noopener">
+                                    {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.gitIcon "class" "git-icon") -}}
+                                    {{- $.GitInfo.AbbreviatedHash -}}
+                                </a>
                             {{- else -}}
-                                {{- $.Scratch.Set "commit" $.GitInfo.AbbreviatedHash -}}
+                                {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.gitIcon "class" "git-icon") -}}
+                                {{- $.GitInfo.AbbreviatedHash -}}
                             {{- end -}}
-                            {{- $commit := .Scratch.Get "commit" -}}
-                            {{- printf `%s` $commit | safeHTML -}}
                         </div>
                     {{ end }}
                     {{ if .Site.Params.displayCommitMessage }}
                         {{ with .GitInfo.Subject }}
-                            {{ $icon := (replace (index $.Site.Data.SVG $.Site.Params.msgIcon) "icon" "icon msg-icon") }}
-                            <div class="gitinfo-item commit-msg">{{ printf `%s%s` $icon . | safeHTML }}</div>
+                            <div class="gitinfo-item commit-msg">
+                                {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.msgIcon "class" "msg-icon") -}}
+                                {{- . -}}
+                            </div>
                         {{ end }}
                     {{ end }}
                 </div>
@@ -28,16 +30,23 @@
                 <div class="post-gitinfo-right">
                     {{ if .Site.Params.displayFeedback }}
                         {{ with .Site.Params.repoURL }}
-                            {{ $icon := (replace (index $.Site.Data.SVG $.Site.Params.feedbackIcon) "icon" "icon feedback-icon") }}
-                            <div class="gitinfo-item feedback">{{ printf `<a href="%s/issues" target="_blank" rel="noopener">%s%s</a>` . $icon $.Site.Params.feedbackText | safeHTML }}</div>
+                            <div class="gitinfo-item feedback">
+                                <a href="{{ . }}/issues" target="_blank" rel="noopener">
+                                    {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.feedbackIcon "class" "feedback-icon") -}}
+                                    {{- $.Site.Params.feedbackText -}}
+                                </a>
+                            </div>
                         {{ end }}
                     {{ end }}
                     {{ if .Site.Params.displayEditLink }}
                         {{ with .Site.Params.repoEditURL }}
-                            {{ $icon := (replace (index $.Site.Data.SVG $.Site.Params.editIcon) "icon" "icon edit-icon") }}
-                            {{ $contentDir := $.Site.Params.contentDir }}
-                            {{ $content := (cond $.Site.IsMultiLingual (printf `/%s/` $contentDir) (printf `/content/`)) }}
-                            <div class="gitinfo-item edit">{{ printf `<a href="%s%s%s" target="_blank" rel="noopener">%s%s</a>` . $content $.Path $icon $.Site.Params.editText | safeHTML }}</div>
+                            {{ $contentDir := (cond $.Site.IsMultiLingual (printf `/%s/` $.Site.Params.contentDir) "/content/") }}
+                            <div class="gitinfo-item edit">
+                                <a href="{{ . }}{{ $contentDir }}{{ $.Path }}" target="_blank" rel="noopener">
+                                    {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.editIcon "class" "edit-icon") -}}
+                                    {{- $.Site.Params.editText -}}
+                                </a>
+                            </div>
                         {{ end }}
                     {{ end }}
                 </div>

--- a/layouts/partials/components/post-meta.html
+++ b/layouts/partials/components/post-meta.html
@@ -56,9 +56,11 @@
                         {{- if ne $index 0 -}}
                             {{- $Deliver.Site.Params.categoryDelimiter | default "/" -}}
                         {{- end -}}
-                        {{- with $Deliver.Site.GetPage (printf `/categories/%s` ($category | urlize)) -}}
+                        <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
+                        {{- $path := (urls.Parse ($category | urlize)).Path -}}
+                        {{- with $Deliver.Site.GetPage (printf `/categories/%s` $path) -}}
                             <a href="{{- .RelPermalink -}}" class="category-link">
-                                {{- .LinkTitle | default $category -}}
+                                {{- .LinkTitle | default $path -}}
                             </a>
                         {{- end -}}
                     {{- end -}}

--- a/layouts/partials/components/post-meta.html
+++ b/layouts/partials/components/post-meta.html
@@ -42,7 +42,7 @@
                             {{- $Deliver.Site.Params.categoryDelimiter | default "/" -}}
                         {{- end -}}
                         <a href="{{- $link | replaceRE `\d+/(.+)` `$1` -}}" class="category-link">
-                          {{- $title -}}
+                            {{- $title -}}
                         </a>
                     {{- end -}}
                 </span>
@@ -58,7 +58,7 @@
                         {{- end -}}
                         {{- with $Deliver.Site.GetPage (printf `/categories/%s` ($category | urlize)) -}}
                             <a href="{{- .RelPermalink -}}" class="category-link">
-                              {{- .LinkTitle | default $category -}}
+                                {{- .LinkTitle | default $category -}}
                             </a>
                         {{- end -}}
                     {{- end -}}

--- a/layouts/partials/components/post-meta.html
+++ b/layouts/partials/components/post-meta.html
@@ -2,19 +2,19 @@
 {{ $isHome := .isHome }}
 <div class="post-meta">
     {{ if and $Deliver.Site.Params.displayPublishedDate (not $Deliver.PublishDate.IsZero) }}
-        {{ $icon := replace (index $Deliver.Site.Data.SVG $Deliver.Site.Params.publishedDateIcon) "icon" "icon post-meta-icon" }}
-        {{ printf `<time datetime="%s" class="post-meta-item published">%s&nbsp;%s</time>` ($Deliver.PublishDate.Format "2006-01-02T15:04:05-07:00") $icon ($Deliver.PublishDate.Format $Deliver.Site.Params.postMetaDateFormat) | safeHTML }}
+        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.publishedDateIcon "class" "post-meta-icon") }}
+        <time datetime="{{ $Deliver.PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item published">{{ $icon }}&nbsp;{{ $Deliver.PublishDate.Format $Deliver.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
     {{ if and $Deliver.Site.Params.displayModifiedDate (not $Deliver.Lastmod.IsZero) }}
-        {{ $icon := replace (index $Deliver.Site.Data.SVG $Deliver.Site.Params.modifiedDateIcon) "icon" "icon post-meta-icon" }}
-        {{ printf `<time datetime="%s" class="post-meta-item modified">%s&nbsp;%s</time>` ($Deliver.Lastmod.Format "2006-01-02T15:04:05-07:00") $icon ($Deliver.Lastmod.Format $Deliver.Site.Params.postMetaDateFormat) | safeHTML }}
+        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.modifiedDateIcon "class" "post-meta-icon") }}
+        <time datetime="{{ $Deliver.Lastmod.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item modified">{{ $icon }}&nbsp;{{ $Deliver.Lastmod.Format $Deliver.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
     {{ if and $Deliver.Site.Params.displayExpiredDate (not $Deliver.ExpiryDate.IsZero) }}
-        {{ $icon := replace (index $Deliver.Site.Data.SVG $Deliver.Site.Params.expiredDateIcon) "icon" "icon post-meta-icon" }}
-        {{ printf `<time datetime="%s" class="post-meta-item expired">%s&nbsp;%s</time>` ($Deliver.ExpiryDate.Format "2006-01-02T15:04:05-07:00") $icon ($Deliver.ExpiryDate.Format $Deliver.Site.Params.postMetaDateFormat) | safeHTML }}
+        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.expiredDateIcon "class" "post-meta-icon") }}
+        <time datetime="{{ $Deliver.ExpiryDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item expired">{{ $icon }}&nbsp;{{ $Deliver.ExpiryDate.Format $Deliver.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
     {{ if $Deliver.Site.Params.displayCategory }}
-        {{ $icon := replace (index $Deliver.Site.Data.SVG $Deliver.Site.Params.categoryIcon) "icon" "icon post-meta-icon" | safeHTML }}
+        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.categoryIcon "class" "post-meta-icon") }}
         {{ if and (eq $Deliver.Site.Params.categoryBy "sections") (in $Deliver.Site.Params.mainSections $Deliver.Section) }}
             {{ $sections := split (strings.TrimSuffix "/" ($Deliver.File.Dir | default $Deliver.Section)) "/" }}
             {{ with $sections }}
@@ -34,38 +34,32 @@
             {{ end }}
             {{ $sections := $Deliver.Scratch.Get "sectionsMeta" }}
             {{ with $sections }}
-                {{ $length := (sub (len $sections) 1) }}
                 <span class="post-meta-item category">
-                    {{- printf `%s&nbsp;` $icon | safeHTML -}}
+                    {{- $icon -}}&nbsp;
                     {{- range $link, $title := $sections -}}
                         {{- $index := $link | replaceRE `(\d+)/.+` `$1` | int -}}
-                        {{- if lt $index $length -}}
-                            {{- $Deliver.Scratch.Set "delimiter" ($Deliver.Site.Params.categoryDelimiter | default "/") -}}
-                        {{- else -}}
-                            {{- $Deliver.Scratch.Set "delimiter" "" -}}
+                        {{- if ne $index 0 }}
+                            {{- $Deliver.Site.Params.categoryDelimiter | default "/" -}}
                         {{- end -}}
-                        {{- $delimiter := ($Deliver.Scratch.Get "delimiter") -}}
-                        {{- printf `<a href="%s" class="category-link">%s</a>%s` ($link | replaceRE `\d+/(.+)` `$1`) $title $delimiter | safeHTML -}}
+                        <a href="{{- $link | replaceRE `\d+/(.+)` `$1` -}}" class="category-link">
+                          {{- $title -}}
+                        </a>
                     {{- end -}}
                 </span>
             {{ end }}
         {{ end }}
         {{ if eq $Deliver.Site.Params.categoryBy "categories" }}
             {{ with $Deliver.Params.categories }}
-                {{ $length := sub (len .) 1 }}
                 <span class="post-meta-item category">
-                    {{- printf `%s&nbsp;` $icon | safeHTML -}}
+                    {{- $icon -}}&nbsp;
                     {{- range $index, $category := . -}}
-                        {{- $url := urls.Parse ($category | urlize) -}}
-                        {{- $path := $url.Path -}}
-                        {{- if lt $index $length -}}
-                            {{- $Deliver.Scratch.Set "delimiter" ($Deliver.Site.Params.categoryDelimiter | default "/") -}}
-                        {{- else -}}
-                            {{- $Deliver.Scratch.Set "delimiter" "" -}}
+                        {{- if ne $index 0 -}}
+                            {{- $Deliver.Site.Params.categoryDelimiter | default "/" -}}
                         {{- end -}}
-                        {{- $delimiter := ($Deliver.Scratch.Get "delimiter") -}}
-                        {{- with $Deliver.Site.GetPage (printf `/categories/%s` $path) -}}
-                            {{- printf `<a href="%s" class="category-link">%s</a>%s` .RelPermalink (.LinkTitle | default $category) $delimiter | safeHTML -}}
+                        {{- with $Deliver.Site.GetPage (printf `/categories/%s` ($category | urlize)) -}}
+                            <a href="{{- .RelPermalink -}}" class="category-link">
+                              {{- .LinkTitle | default $category -}}
+                            </a>
                         {{- end -}}
                     {{- end -}}
                 </span>
@@ -73,16 +67,16 @@
         {{ end }}
     {{ end }}
     {{ if $Deliver.Site.Params.displayWordCount }}
-        {{ $icon := replace (index $Deliver.Site.Data.SVG $Deliver.Site.Params.wordCountIcon) "icon" "icon post-meta-icon" | safeHTML }}
+        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.wordCountIcon "class" "post-meta-icon") }}
         <span class="post-meta-item wordcount">{{ $icon }}&nbsp;{{ $Deliver.WordCount }}</span>
     {{ end }}
     {{ if $Deliver.Site.Params.displayReadingTime }}
-        {{ $icon := replace (index $Deliver.Site.Data.SVG $Deliver.Site.Params.readingTimeIcon) "icon" "icon post-meta-icon" | safeHTML }}
+        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.readingTimeIcon "class" "post-meta-icon") }}
         <span class="post-meta-item reading-time">{{ $icon }}&nbsp;{{ $Deliver.ReadingTime }}&nbsp;{{ i18n "minute" $Deliver.ReadingTime }}</span>
     {{ end }}
     {{ if and $Deliver.Site.Params.displayBusuanziPagePV (eq hugo.Environment "production") }}
         {{ if not $isHome }}
-            {{ $icon := replace (index $Deliver.Site.Data.SVG $Deliver.Site.Params.busuanziPagePVIcon) "icon" "icon post-meta-icon" | safeHTML }}
+            {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.busuanziPagePVIcon "class" "post-meta-icon") }}
             <span class="post-meta-item busuanzi-page-pv" id="busuanzi_container_page_pv">{{ $icon }}&nbsp;<span id="busuanzi_value_page_pv"></span></span>
         {{ end }}
     {{ end }}

--- a/layouts/partials/components/post-nav.html
+++ b/layouts/partials/components/post-nav.html
@@ -12,12 +12,12 @@
         <ul class="post-nav">
             {{ if $next }}
                 <li class="post-nav-prev">
-                    <a href="{{ $next.RelPermalink }}" rel="prev">{{ printf `< %s` $next.LinkTitle | safeHTML }}</a>
+                    <a href="{{ $next.RelPermalink }}" rel="prev">&lt; {{$next.LinkTitle}}</a>
                 </li>
             {{ end }}
             {{ if $prev }}
                 <li class="post-nav-next">
-                    <a href="{{ $prev.RelPermalink }}" rel="next">{{ printf `%s >` $prev.LinkTitle | safeHTML }}</a>
+                    <a href="{{ $prev.RelPermalink }}" rel="next">{{ $prev.LinkTitle }} &gt;</a>
                 </li>
             {{ end }}
         </ul>

--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -1,7 +1,6 @@
 {{ if and .Site.Params.enablePostShare (.Params.share | default .Site.Params.displayPostShare) }}
 
-    {{- partial "utils/summary.html" . -}}
-    {{- $description := .Description | default (.Scratch.Get "summary") | default .Site.Params.siteDescription | plainify -}}
+    {{- $description := .Description | default (partial "utils/summary.html" .) | default .Site.Params.siteDescription | plainify -}}
 
     {{- partial "utils/images.html" . -}}
     {{- $images := .Scratch.Get "images" -}}

--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -32,61 +32,55 @@
         <div class="share-items">
 
             {{ if .Site.Params.shareOnTwitter }}
-                {{ $icon := (replace .Site.Data.SVG.twitter "icon" "icon twitter-icon") }}
                 <div class="share-item twitter">
                     {{ $url := (printf `https://twitter.com/share?url=%s&text=%s&hashtags=%s&via=%s` .Permalink .Title ($hashtags.Get "tags" | default "") .Site.Params.siteTwitter) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "twitter" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "twitter" "class" "twitter-icon") -}}
                     </a>
                 </div>
             {{ end }}
 
             {{ if .Site.Params.shareOnFacebook }}
-                {{ $icon := (replace .Site.Data.SVG.facebook "icon" "icon facebook-icon") }}
                 <div class="share-item facebook">
                     {{ $url := (printf `https://www.facebook.com/sharer/sharer.php?u=%s&hashtag=%s` .Permalink ($hashtags.Get "firsttag" | default "")) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "facebook" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "facebook" "class" "facebook-icon") -}}
                     </a>
                 </div>
             {{ end }}
 
             {{ if .Site.Params.shareOnLinkedIn }}
-                {{ $icon := (replace .Site.Data.SVG.linkedin "icon" "icon linkedin-icon") }}
                 <div class="share-item linkedin">
                     {{ $url := (printf `https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s&summary=%s&source=%s` .Permalink .Title $description .Site.Title) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "linkedin" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "linkedin" "class" "linkedin-icon") -}}
                     </a>
                 </div>
             {{ end }}
 
             {{ if .Site.Params.shareOnTelegram }}
-                {{ $icon := (replace .Site.Data.SVG.telegram "icon" "icon telegram-icon") }}
                 <div class="share-item telegram">
                     {{ $url := (printf `https://t.me/share/url?url=%s&text=%s` .Permalink .Title) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "telegram" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "telegram" "class" "telegram-icon") -}}
                     </a>
                 </div>
             {{ end }}
 
             {{ if .Site.Params.shareOnWeibo }}
-                {{ $icon := (replace .Site.Data.SVG.weibo "icon" "icon weibo-icon") }}
                 <div class="share-item weibo">
                     {{ $url := (printf `https://service.weibo.com/share/share.php?&url=%s&title=%s&pic=%s&searchPic=false` .Permalink .Title $images) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "weibo" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "weibo" "class" "weibo-icon") -}}
                     </a>
                 </div>
             {{ end }}
 
             {{ if .Site.Params.shareOnDouban }}
-                {{ $icon := (replace .Site.Data.SVG.douban "icon" "icon douban-icon") }}
                 <div class="share-item douban">
                     {{ $url := (printf `https://www.douban.com/share/service?href=%s&name=%s&text=%s` .Permalink .Title $description) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "douban" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "douban" "class" "douban-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -96,26 +90,24 @@
                 <div class="share-item qq">
                     {{ $url := (printf `https://connect.qq.com/widget/shareqq/index.html?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink .Title $description $images .Site.Title) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qq" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "qq" "class" "qq-icon") -}}
                     </a>
                 </div>
             {{ end }}
 
             {{ if .Site.Params.shareOnQzone }}
-                {{ $icon := (replace .Site.Data.SVG.qzone "icon" "icon qzone-icon") }}
                 <div class="share-item qzone">
                     {{ $url := (printf `https://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink .Title $description $images .Site.Title) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qzone" }}" target="_blank" rel="noopener">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "qzone" "class" "qzone-icon") -}}
                     </a>
                 </div>
             {{ end }}
 
             {{ if .Site.Params.shareViaQRCode }}
-                {{ $icon := (replace .Site.Data.SVG.qrcode "icon" "icon qrcode-icon") }}
                 <div class="share-item qrcode">
                     <div class="qrcode-container" title="{{ i18n "shareViaTitle" }}{{ i18n "qrcode" }}">
-                        {{- $icon | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "qrcode" "class" "qrcode-icon") -}}
                         <div id="qrcode-img"></div>
                     </div>
                     {{ partial "third-party/qrcode-generator.html" . }}

--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -85,7 +85,6 @@
             {{ end }}
 
             {{ if .Site.Params.shareOnQQ }}
-                {{ $icon := (replace .Site.Data.SVG.qq "icon" "icon qq-icon") }}
                 <div class="share-item qq">
                     {{ $url := (printf `https://connect.qq.com/widget/shareqq/index.html?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink .Title $description $images .Site.Title) }}
                     <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qq" }}" target="_blank" rel="noopener">

--- a/layouts/partials/components/post-tags.html
+++ b/layouts/partials/components/post-tags.html
@@ -3,11 +3,9 @@
         <div class="post-tags">
             {{ range . }}
                 {{ $tag := . }}
-                {{ $url := urls.Parse (. | urlize) }}
-                {{ $path := $url.Path }}
-                {{ with $.Site.GetPage (printf `/tags/%s` $path) }}
-                    {{ $icon := (replace (index $.Site.Data.SVG $.Site.Params.postTagsIcon) "icon" "icon tag-icon") }}
-                    <a href="{{ .RelPermalink }}" rel="tag" class="post-tags-link">{{ $icon | safeHTML }}{{ .LinkTitle | default $tag }}</a>
+                {{ with $.Site.GetPage (printf `/tags/%s` ($tag | urlize)) }}
+                    {{ $icon := partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.postTagsIcon "class" "tag-icon") }}
+                    <a href="{{ .RelPermalink }}" rel="tag" class="post-tags-link">{{ $icon  }}{{ .LinkTitle | default $tag }}</a>
                 {{ end }}
             {{ end }}
         </div>

--- a/layouts/partials/components/post-tags.html
+++ b/layouts/partials/components/post-tags.html
@@ -3,9 +3,11 @@
         <div class="post-tags">
             {{ range . }}
                 {{ $tag := . }}
-                {{ with $.Site.GetPage (printf `/tags/%s` ($tag | urlize)) }}
+                <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
+                {{ $path := (urls.Parse ($tag | urlize)).Path }}
+                {{ with $.Site.GetPage (printf `/tags/%s` $path) }}
                     {{ $icon := partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.postTagsIcon "class" "tag-icon") }}
-                    <a href="{{ .RelPermalink }}" rel="tag" class="post-tags-link">{{ $icon  }}{{ .LinkTitle | default $tag }}</a>
+                    <a href="{{ .RelPermalink }}" rel="tag" class="post-tags-link">{{ $icon  }}{{ .LinkTitle | default $path }}</a>
                 {{ end }}
             {{ end }}
         </div>

--- a/layouts/partials/components/post-updated-badge.html
+++ b/layouts/partials/components/post-updated-badge.html
@@ -1,16 +1,12 @@
 {{ if and .Site.Params.enablePostUpdatedBadge (.Params.badge | default .Site.Params.displayUpdatedBadge) }}
     <div class="updated-badge-container">
-        {{- if .Site.Params.enableBadgeTitle -}}
-            {{- $date := .Lastmod.Format "2006-01-02 15:04:05 MST" -}}
-            {{- $title := (printf ` title="%s%s"` .Site.Params.badgeTitlePrefix $date) -}}
-            {{- .Scratch.Set "title" $title -}}
-        {{- else -}}
-            {{- .Scratch.Set "title" "" -}}
-        {{- end }}
-        {{- $title := .Scratch.Get "title" | safeHTML -}}
         {{- $date := .Lastmod.Format "2006-01-02" -}}
-        {{- with $title -}}{{- printf `<div%s style="cursor:help;display:inline-block">` $title | safeHTML -}}{{- end -}}
+        {{- if .Site.Params.enableBadgeTitle }}
+        <span title="{{ .Site.Params.badgeTitlePrefix }}{{ .Lastmod.Format "2006-01-02 15:04:05 MST" }}" style="cursor:help">
+        {{- end -}}
             {{- partial "utils/updated-badge.html" (dict "date" $date) -}}
-        {{- with $title -}}</div>{{- end -}}
+        {{- if .Site.Params.enableBadgeTitle }}
+        </span>
+        {{- end -}}
     </div>
 {{ end }}

--- a/layouts/partials/components/related-posts.html
+++ b/layouts/partials/components/related-posts.html
@@ -2,7 +2,7 @@
     {{ $related := .Site.RegularPages.Related . | first (.Site.Params.relatedPostsNumber | default 5) }}
     {{ with $related }}
         <div class="related-posts">
-            <h2 class="related-title">{{ i18n "relatedPosts" }}{{ replace (index $.Site.Data.SVG $.Site.Params.relatedPostsIcon) "icon" "icon related-icon" | safeHTML }}</h2>
+            <h2 class="related-title">{{ i18n "relatedPosts" }}{{ partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.relatedPostsIcon "class" "related-icon") }}</h2>
             <ul class="related-list">
                 {{ range . }}
                     <li class="related-item">

--- a/layouts/partials/components/socials.html
+++ b/layouts/partials/components/socials.html
@@ -4,7 +4,7 @@
             {{- range sort .socials "weight" -}}
                 <li class="socials-item">
                     <a href="{{ .url }}" target="_blank" rel="external noopener" title="{{ .title }}">
-                        {{- replace (index $.Site.Data.SVG .icon) "icon" "icon social-icon" | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" $ "name" .icon "class" "social-icon") -}}
                     </a>
                 </li>
             {{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,7 +8,7 @@
               {{- end -}}
 
               {{- if .Site.Params.displaySiteCreatedYear -}}
-                  {{- dateFormat "2006" (time .Site.Params.siteCreatedTime) -}}-
+                  {{- dateFormat "2006" (time .Site.Params.siteCreatedTime) -}}–
               {{- end -}}
               {{- now.Format "2006" -}}
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,7 +4,7 @@
         <div class="footer-inner">
             <div class="site-info">
               {{- if .Site.Params.displayCopyrightSymbol -}}
-                  {{- "©" -}}&nbsp;
+                  ©&nbsp;
               {{- end -}}
 
               {{- if .Site.Params.displaySiteCreatedYear -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -46,36 +46,34 @@
                 <div class="busuanzi-site-uv-and-pv">
                     <span id="busuanzi_container_site_uv">
                         {{- with .Site.Params.busuanziSiteUVText -}}
-                            {{- $.Scratch.Set "busuanziSiteUVText" (printf `%s&nbsp;` .) -}}
-                        {{- else -}}
-                            {{- $.Scratch.Set "busuanziSiteUVText" "" -}}
+                            {{- . -}}
+                            &nbsp;
                         {{- end -}}
-                        {{- $busuanziSiteUVText := .Scratch.Get "busuanziSiteUVText" -}}
+
                         {{- with .Site.Params.busuanziSiteUVIcon -}}
-                            {{- $busuanziSiteUVIcon := replace (index $.Site.Data.SVG $.Site.Params.busuanziSiteUVIcon) "icon" "icon busuanzi-site-uv" -}}
-                            {{- $.Scratch.Set "busuanziSiteUVIcon" (printf `%s&nbsp;` $busuanziSiteUVIcon) -}}
-                        {{- else -}}
-                            {{- $.Scratch.Set "busuanziSiteUVIcon" "" -}}
+                            {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.busuanziSiteUVIcon "class" "busuanzi-site-uv") -}}
+                            &nbsp;
                         {{- end -}}
-                        {{- $busuanziSiteUVIcon := .Scratch.Get "busuanziSiteUVIcon" -}}
-                        {{- printf `%s%s%s` $busuanziSiteUVText $busuanziSiteUVIcon `<span id="busuanzi_value_site_uv"></span>` | safeHTML -}}
+
+                        <!-- Avoid extra spaces -->
+                        {{- print `<span id="busuanzi_value_site_uv"></span>` | safeHTML -}}
                     </span>
+
                     {{- print "&nbsp;|&nbsp;" | safeHTML -}}
+
                     <span id="busuanzi_container_site_pv">
                         {{- with .Site.Params.busuanziSitePVText -}}
-                            {{- $.Scratch.Set "busuanziSitePVText" (printf `%s&nbsp;` .) -}}
-                        {{- else -}}
-                            {{- $.Scratch.Set "busuanziSitePVText" "" -}}
+                            {{- . -}}
+                            &nbsp;
                         {{- end -}}
-                        {{- $busuanziSitePVText := .Scratch.Get "busuanziSitePVText" -}}
+
                         {{- with .Site.Params.busuanziSitePVIcon -}}
-                            {{- $busuanziSitePVIcon := replace (index $.Site.Data.SVG $.Site.Params.busuanziSitePVIcon) "icon" "icon busuanzi-site-pv" -}}
-                            {{- $.Scratch.Set "busuanziSitePVIcon" (printf `%s&nbsp;` $busuanziSitePVIcon) -}}
-                        {{- else -}}
-                            {{- $.Scratch.Set "busuanziSitePVIcon" "" -}}
+                            {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.busuanziSitePVIcon "class" "busuanzi-site-pv") -}}
+                            &nbsp;
                         {{- end -}}
-                        {{- $busuanziSitePVIcon := .Scratch.Get "busuanziSitePVIcon" -}}
-                        {{- printf `%s%s%s` $busuanziSitePVText $busuanziSitePVIcon `<span id="busuanzi_value_site_pv"></span>` | safeHTML -}}
+
+                        <!-- Avoid extra spaces -->
+                        {{- print `<span id="busuanzi_value_site_pv"></span>` | safeHTML -}}
                     </span>
                 </div>
             {{- end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,48 +2,44 @@
 {{ if or (and .IsHome .Site.Params.displayFooterInHome) (and (not .IsHome) .Site.Params.enableFooter) }}
     <footer id="footer" class="footer">
         <div class="footer-inner">
-            {{- if .Site.Params.displayCopyrightSymbol -}}
-                {{- .Scratch.Set "siteInfoCopyright" "©&nbsp;" -}}
-            {{- else -}}
-                {{- .Scratch.Set "siteInfoCopyright" "" -}}
-            {{- end -}}
-            {{- $siteInfoCopyright := .Scratch.Get "siteInfoCopyright" -}}
+            <div class="site-info">
+              {{- if .Site.Params.displayCopyrightSymbol -}}
+                  {{- "©" -}}&nbsp;
+              {{- end -}}
 
-            {{- if .Site.Params.displaySiteCreatedYear -}}
-                {{- .Scratch.Set "siteInfoCreatedYear" (printf `%s–%s` (dateFormat "2006" (time .Site.Params.siteCreatedTime)) (now.Format "2006")) -}}
-            {{- else -}}
-                {{- .Scratch.Set "siteInfoCreatedYear" (now.Format "2006") -}}
-            {{- end -}}
-            {{- $siteInfoCreatedYear := .Scratch.Get "siteInfoCreatedYear" -}}
+              {{- if .Site.Params.displaySiteCreatedYear -}}
+                  {{- dateFormat "2006" (time .Site.Params.siteCreatedTime) -}}-
+              {{- end -}}
+              {{- now.Format "2006" -}}
 
-            {{- with .Site.Params.iconBetweenYearAndAuthor -}}
-                {{- $.Scratch.Set "siteInfoIcon" (printf `&nbsp;%s&nbsp;` (replace (index $.Site.Data.SVG .) "icon" "icon footer-icon")) -}}
-            {{- else -}}
-                {{- $.Scratch.Set "siteInfoIcon" "&nbsp;" -}}
-            {{- end -}}
-            {{- $siteInfoIcon := .Scratch.Get "siteInfoIcon" -}}
+              {{- with .Site.Params.iconBetweenYearAndAuthor -}}
+                  &nbsp;{{- partial "utils/icon.html" (dict "Deliver" $Deliver "name" . "class" "footer-icon") -}}&nbsp;
+              {{- else -}}
+                  &nbsp;
+              {{- end -}}
 
-            <div class="site-info">{{ printf `%s%s%s%s` $siteInfoCopyright $siteInfoCreatedYear $siteInfoIcon .Site.Author.name | safeHTML }}</div>
+              {{- .Site.Author.name -}}
+            </div>
 
             {{- if .Site.Params.displayPoweredBy }}
                 {{- $raw := `Powered by [Hugo](https://github.com/gohugoio/hugo) | Theme is [MemE](https://github.com/reuixiy/hugo-theme-meme)` -}}
                 {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
                 {{- $Content := .Scratch.Get "Content" -}}
-                <div class="powered-by">{{ $Content | safeHTML }}</div>
+                <div class="powered-by">{{ $Content }}</div>
             {{- end }}
 
             {{- if .Site.Params.displaySiteCopyright }}
                 {{- $raw := .Site.Copyright -}}
                 {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
                 {{- $Content := .Scratch.Get "Content" -}}
-                <div class="site-copyright">{{ $Content | safeHTML }}</div>
+                <div class="site-copyright">{{ $Content }}</div>
             {{- end }}
 
             {{- with .Site.Params.customFooter }}
                 {{- $raw := . -}}
                 {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
                 {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                <div class="custom-footer">{{ $Content | safeHTML }}</div>
+                <div class="custom-footer">{{ $Content }}</div>
             {{- end }}
 
             {{- if and .Site.Params.displayBusuanziSiteUVAndPV (eq hugo.Environment "production") }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -108,10 +108,10 @@
 
     <!-- Atom / RSS -->
     {{ with .OutputFormats.Get "SectionsAtom" -}}
-        {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType .Permalink $.Site.Title | safeHTML }}
+        <link rel="{{ .Rel }}" type="{{ .MediaType }}" href="{{ .Permalink }}" title="{{ $.Site.Title }}" />
     {{ end -}}
     {{ with .OutputFormats.Get "SectionsRSS" -}}
-        {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType .Permalink $.Site.Title | safeHTML }}
+        <link rel="{{ .Rel }}" type="{{ .MediaType }}" href="{{ .Permalink }}" title="{{ $.Site.Title }}" />
     {{ end }}
 
     <!-- SEO -->

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -76,8 +76,7 @@
     {{- end }}
 
     <meta name="author" content="{{ .Params.author | default .Site.Author.name }}" />
-    {{ partial "utils/summary.html" . }}
-    {{- $description := .Description | default (.Scratch.Get "summary") | default .Site.Params.siteDescription | plainify -}}
+    {{- $description := .Description | default (partial "utils/summary.html" .) | default .Site.Params.siteDescription | plainify -}}
     <meta name="description" content="{{ $description }}" />
 
     <!-- Favicon, Icons, Web App -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,7 +17,7 @@
 {{ define "site-brand" }}
     <div class="site-brand">
         {{ if .Site.Params.siteBrandSVG }}
-            <a href="{{ print `/` | relLangURL }}">{{ .Site.Data.SVG.brand | safeHTML }}</a>
+            <a href="{{ print `/` | relLangURL }}">{{ partial "utils/icon.html" (dict "Deliver" . "name" "brand") }}</a>
         {{ else }}
             <a href="{{ print `/` | relLangURL }}" class="brand">{{ .Site.Title }}</a>
         {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,6 +5,7 @@
                 <div class="header-inner">
                     {{ template "site-brand" . }}
                     {{ partial "menu.html" . }}
+                    {{ partial "custom/header.html" . }}
                 </div>
             </div>
             {{ partial "components/nav-toggle.html" . }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -27,10 +27,9 @@
                     {{- $linkType := (string .Pre) -}}
                     <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>
                         {{- $iconName := (string .Post) -}}
-                        {{- $icon := (index $.Site.Data.SVG $iconName) -}}
-                        {{- printf `%s` (replace $icon "icon" (printf `icon %s` .Identifier)) | safeHTML -}}
+                        {{- partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) -}}
                         {{- with .Name -}}
-                            {{- printf `<span class="menu-item-name">%s</span>` . | safeHTML -}}
+                            <span class="menu-item-name">{{ . }}</span>
                         {{- end -}}
                     </a>
                 </li>

--- a/layouts/partials/pages/home-footage.html
+++ b/layouts/partials/pages/home-footage.html
@@ -26,8 +26,7 @@
                 {{ range $index, $value := . }}
                     {{- $linkType := (string .Pre) -}}
                     {{- $iconName := (string .Post) -}}
-                    {{- $icon := (index $.Site.Data.SVG $iconName) -}}
-                    <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ replace $icon "icon" (printf `icon %s` .Identifier) | safeHTML }}{{ .Name }}</a>
+                    <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{- if lt $index $length -}}
                         {{- $.Site.Params.homeLinksDelimiter -}}
                     {{- end -}}

--- a/layouts/partials/pages/home-poetry.html
+++ b/layouts/partials/pages/home-poetry.html
@@ -5,7 +5,7 @@
             {{- $raw := . -}}
             {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
             {{- $Content := $Deliver.Scratch.Get "Content" -}}
-            <p>{{ $Content | safeHTML }}</p>
+            <p>{{ $Content }}</p>
         {{ end }}
     </div>
     {{ with .Site.Menus.home }}
@@ -13,8 +13,7 @@
             {{ range . }}
                 {{- $linkType := (string .Pre) -}}
                 {{- $iconName := (string .Post) -}}
-                {{- $icon := (index $.Site.Data.SVG $iconName) -}}
-                <a href="{{ .URL }}" class="links-item"{{ if eq $linkType "external" }} target="_blank" rel="noopener"{{ end }}>{{ replace $icon "icon" (printf `icon %s` .Identifier) | safeHTML }}{{ .Name }}</a>
+                <a href="{{ .URL }}" class="links-item"{{ if eq $linkType "external" }} target="_blank" rel="noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
             {{ end }}
         </div>
     {{ end }}

--- a/layouts/partials/pages/home-posts.html
+++ b/layouts/partials/pages/home-posts.html
@@ -11,8 +11,6 @@
                 {{ end }}
                 <summary class="summary">
                     {{ partial "utils/summary.html" . }}
-                    {{ $summary := .Scratch.Get "summary" }}
-                    {{ $summary | safeHTML }}
                 </summary>
                 {{ if .Truncated }}
                     <div class="read-more-container">
@@ -25,12 +23,12 @@
             <ul class="pagination">
                 {{ if $paginator.HasPrev }}
                     <li class="pagination-prev">
-                        <a href="{{ $paginator.Prev.URL }}" rel="prev">{{ printf `< %s` (i18n "prevPage") | safeHTML }}</a>
+                        <a href="{{ $paginator.Prev.URL }}" rel="prev">&lt; {{ i18n "prevPage" }}</a>
                     </li>
                 {{ end }}
                 {{ if $paginator.HasNext }}
                     <li class="pagination-next">
-                        <a href="{{ $paginator.Next.URL }}" rel="next">{{ printf `%s >` (i18n "nextPage") | safeHTML }}</a>
+                        <a href="{{ $paginator.Next.URL }}" rel="next">{{ i18n "nextPage" }} &gt;</a>
                     </li>
                 {{ end }}
             </ul>

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -24,7 +24,7 @@
                 {{- $raw := . -}}
                 {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
                 {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                <div class="post-subtitle">{{ $Content | safeHTML }}</div>
+                <div class="post-subtitle">{{ $Content }}</div>
             {{ end }}
 
             {{ if .Site.Params.displayPostDescription }}
@@ -32,7 +32,7 @@
                     {{- $raw := . -}}
                     {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
                     {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                    <div class="post-description">{{ $Content | safeHTML }}</div>
+                    <div class="post-description">{{ $Content }}</div>
                 {{ end }}
             {{ end }}
 

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -47,10 +47,10 @@
 
 {{- if .Site.Params.enableFingerprint -}}
     {{- $script := .Scratch.Get "script" | resources.Concat $path | resources.Minify | resources.Fingerprint -}}
-    {{- printf `<script src="%s" integrity="%s"></script>` $script.RelPermalink $script.Data.Integrity | safeHTML -}}
+    <script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity }}"></script>
 {{- else -}}
     {{- $script := .Scratch.Get "script" | resources.Concat $path | resources.Minify -}}
-    {{- printf `<script src="%s"></script>` $script.RelPermalink | safeHTML -}}
+    <script src="{{ $script.RelPermalink }}"></script>
 {{- end }}
 
 {{ if .Site.Params.enableSmoothScroll }}

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -3,8 +3,8 @@
 
 {{- if .Site.Params.enableFingerprint -}}
     {{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate (printf "%s/styles/main-rendered.scss" .Lang) . | resources.ToCSS $options | resources.Fingerprint -}}
-    {{- printf `<link rel="stylesheet" href="%s" integrity="%s" />` $style.RelPermalink $style.Data.Integrity | safeHTML -}}
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" />
 {{- else -}}
     {{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate (printf "%s/styles/main-rendered.scss" .Lang) . | resources.ToCSS $options -}}
-    {{- printf `<link rel="stylesheet" href="%s" />` $style.RelPermalink | safeHTML -}}
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
 {{- end -}}

--- a/layouts/partials/utils/auto-detect-images.html
+++ b/layouts/partials/utils/auto-detect-images.html
@@ -2,14 +2,14 @@
 <!-- https://gohugo.io/functions/replacere/ -->
 <!-- https://regex101.com/ -->
 {{- if and .IsPage (in .Site.Params.mainSections .Section) -}}
-    {{- $imgs := findRE `<img src="/?([^"]+)` .Content | uniq -}}
+    {{- $imgs := findRE `<img(?:\s+[\w-]+="[^"]*")*\s+src="/?([^"]+)` .Content | uniq -}}
     {{- with $imgs -}}
         {{- $.Scratch.Delete "imgsURL" -}}
         {{- range . -}}
             {{- $.Scratch.Delete "replacement" -}}
             {{- if and $.Site.Params.enableImageHost $.Site.Params.headAlso -}}
                 {{- if (eq hugo.Environment "production") -}}
-                    {{- $url := replaceRE `<img src="/?([^"]+)` `$1` . -}}
+                    {{- $url := replaceRE `<img(?:\s+[\w-]+="[^"]*")*\s+src="/?([^"]+)` `$1` . -}}
                     {{- if ne (substr $url 0 4) "http" -}}
                         {{- $hostURL := $.Site.Params.imageHostURL -}}
                         {{- $replacement := (printf `%s$1` $hostURL) -}}
@@ -22,7 +22,7 @@
                 {{- $.Scratch.Set "replacement" `$1` -}}
             {{- end -}}
             {{- $replacement := $.Scratch.Get "replacement" -}}
-            {{- $imgsURL := replaceRE `<img src="/?([^"]+)` $replacement . -}}
+            {{- $imgsURL := replaceRE `<img(?:\s+[\w-]+="[^"]*")*\s+src="/?([^"]+)` $replacement . -}}
             {{- $.Scratch.Add "imgsURL" (slice $imgsURL) -}}
         {{- end -}}
     {{- end -}}

--- a/layouts/partials/utils/auto-detect-images.html
+++ b/layouts/partials/utils/auto-detect-images.html
@@ -2,14 +2,14 @@
 <!-- https://gohugo.io/functions/replacere/ -->
 <!-- https://regex101.com/ -->
 {{- if and .IsPage (in .Site.Params.mainSections .Section) -}}
-    {{- $imgs := findRE `<img(?:\s+[\w-]+="[^"]*")*\s+src="/?([^"]+)` .Content | uniq -}}
+    {{- $imgs := findRE `<img src="/?([^"]+)` .Content | uniq -}}
     {{- with $imgs -}}
         {{- $.Scratch.Delete "imgsURL" -}}
         {{- range . -}}
             {{- $.Scratch.Delete "replacement" -}}
             {{- if and $.Site.Params.enableImageHost $.Site.Params.headAlso -}}
                 {{- if (eq hugo.Environment "production") -}}
-                    {{- $url := replaceRE `<img(?:\s+[\w-]+="[^"]*")*\s+src="/?([^"]+)` `$1` . -}}
+                    {{- $url := replaceRE `<img src="/?([^"]+)` `$1` . -}}
                     {{- if ne (substr $url 0 4) "http" -}}
                         {{- $hostURL := $.Site.Params.imageHostURL -}}
                         {{- $replacement := (printf `%s$1` $hostURL) -}}
@@ -22,7 +22,7 @@
                 {{- $.Scratch.Set "replacement" `$1` -}}
             {{- end -}}
             {{- $replacement := $.Scratch.Get "replacement" -}}
-            {{- $imgsURL := replaceRE `<img(?:\s+[\w-]+="[^"]*")*\s+src="/?([^"]+)` $replacement . -}}
+            {{- $imgsURL := replaceRE `<img src="/?([^"]+)` $replacement . -}}
             {{- $.Scratch.Add "imgsURL" (slice $imgsURL) -}}
         {{- end -}}
     {{- end -}}

--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -105,8 +105,8 @@
 <!-- Replace `footnoteReturnLinkContents` with icon -->
 {{- $Content := .Scratch.Get "Content" -}}
 {{- with .Site.Params.footnoteReturnLinkIcon -}}
-    {{- $icon := (replace (index $.Site.Data.SVG .) "icon" "icon footnote-icon") -}}
-    {{- $replacement := (printf `${1}%s$3` $icon) | safeHTML -}}
+    {{- $icon := (partial "utils/icon.html" (dict "Deliver" $ "name" . "class" "footnote-icon")) -}}
+    {{- $replacement := (printf `${1}%s$3` $icon) -}}
 
     {{- $regexPatternfootnoteReturnLinkIcon := `(href="#fnref[^>]+>)([^<]+)(.+)` -}}
     {{- $regexReplacementfootnoteReturnLinkIcon := $replacement -}}

--- a/layouts/partials/utils/icon.html
+++ b/layouts/partials/utils/icon.html
@@ -1,0 +1,6 @@
+{{- $Deliver := .Deliver -}}
+{{- $name := .name -}}
+{{- $class := .class | default $name -}}
+{{- $icon := index $Deliver.Site.Data.SVG $name -}}
+{{- $class := printf "icon %s" $class -}}
+{{- return (replace $icon "icon" $class | safeHTML) -}}

--- a/layouts/partials/utils/images.html
+++ b/layouts/partials/utils/images.html
@@ -28,7 +28,7 @@
 {{- .Scratch.Delete "images" -}}
 {{- with $imagesParam | default $imgsURL -}}
     {{- range . -}}
-        {{- $image := . | absURL | safeHTML -}}
+        {{- $image := . | absURL -}}
         {{- $.Scratch.Add "images" (slice $image) -}}
     {{- end -}}
 {{- end -}}

--- a/layouts/partials/utils/list-item.html
+++ b/layouts/partials/utils/list-item.html
@@ -1,6 +1,6 @@
 {{ range .Pages }}
     <li class="list-item">
         <a href="{{ .RelPermalink }}" class="list-item-title">{{ .LinkTitle }}</a>
-        {{ printf `<time datetime="%s" class="list-item-time">%s</time>` (.PublishDate.Format "2006-01-02T15:04:05-07:00") (.PublishDate.Format .Site.Params.listDateFormat) | safeHTML }}
+        <time datetime="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="list-item-time">{{ .PublishDate.Format .Site.Params.listDateFormat }}</time>
     </li>
 {{ end }}

--- a/layouts/partials/utils/open-graph.html
+++ b/layouts/partials/utils/open-graph.html
@@ -42,10 +42,10 @@
 
 {{- if and $Deliver.IsPage (in $Deliver.Site.Params.mainSections $Deliver.Section) -}}
     <meta property="og:type" content="article" />
-    {{ printf `<meta property="article:published_time" content="%s" />` $pubDate | safeHTML }}
-    {{ printf `<meta property="article:modified_time" content="%s" />` $modDate | safeHTML }}
+    <meta property="article:published_time" content="{{ $pubDate }}" />
+    <meta property="article:modified_time" content="{{ $modDate }}" />
     {{ if not $Deliver.ExpiryDate.IsZero -}}
-        {{ printf `<meta property="article:expiration_time" content="%s" />` ($Deliver.ExpiryDate.Format "2006-01-02T15:04:05-07:00") | safeHTML }}
+        <meta property="article:expiration_time" content="{{ $Deliver.ExpiryDate.Format "2006-01-02T15:04:05-07:00" }}" />
     {{- end }}
     <meta property="article:section" content="{{ $Deliver.Section }}" />
 {{ else -}}

--- a/layouts/partials/utils/relative-url.html
+++ b/layouts/partials/utils/relative-url.html
@@ -5,7 +5,7 @@
 {{- $depth := (len (split (strings.TrimSuffix "/" $url) "/")) -}}
 
 {{- if eq $depth 1 -}}
-    {{- $url := printf "./%s" $filename | safeHTML -}}
+    {{- $url := printf "./%s" $filename -}}
     {{- $Deliver.Scratch.Set "url" $url -}}
 {{- else -}}
     {{- $Deliver.Scratch.Set "level" "" -}}

--- a/layouts/partials/utils/summary.html
+++ b/layouts/partials/utils/summary.html
@@ -1,16 +1,14 @@
 {{ if .Truncated -}}
     <!-- For the CJK language, add ellipsis. -->
     {{- if .Params.isCJKLanguage -}}
-        {{- $summary := printf "%s%s" .Summary (i18n "ellipsis") -}}
-        {{- $.Scratch.Set "summary" $summary -}}
+        {{- .Summary -}}
+        {{- i18n "ellipsis" -}}
     <!-- For the other languages, no need. -->
-    <!-- Hugo’s automatic summary split method will split untill where the sentence end. -->
+    <!-- Hugo’s automatic summary split method will split until end of sentence. -->
     <!-- (Tested English Only) -->
     {{- else -}}
-        {{- $summary := .Summary -}}
-        {{- $.Scratch.Set "summary" $summary -}}
+        {{- .Summary -}}
     {{- end -}}
 {{- else -}}
-    {{- $summary := .Summary -}}
-    {{- $.Scratch.Set "summary" $summary -}}
+    {{- .Summary -}}
 {{- end -}}


### PR DESCRIPTION
This adds a `custom/header.html` partial which is empty by default but can be overridden to add custom elements to the header.