### PR TITLE
Fixes #151 - Move headings out of <ul> tag

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -46,49 +46,47 @@
                     <!-- Start List -->
                     {{ $pages := .Scratch.Get "pages" }}
                     {{ range $pages.GroupByDate "2006" }}
-                        <ul class="list-part">
-                            {{ $.Scratch.Delete "zodiacName" }}
-                            {{ if $.Site.Params.chineseZodiac }}
-                                {{ $zodiacName := (index $.Site.Data.ChineseZodiac (string (mod .Key 12))) }}
-                                {{ $.Scratch.Set "zodiacName" $zodiacName }}
+                        {{ $.Scratch.Delete "zodiacName" }}
+                        {{ if $.Site.Params.chineseZodiac }}
+                            {{ $zodiacName := (index $.Site.Data.ChineseZodiac (string (mod .Key 12))) }}
+                            {{ $.Scratch.Set "zodiacName" $zodiacName }}
+                        {{ end }}
+                        {{ $zodiacName := $.Scratch.Get "zodiacName" }}
+                        {{ $.Scratch.Delete "year" }}
+                        {{ if $.Site.Params.i18nYear }}
+                            {{ $key := .Key }}
+                            {{ $.Scratch.Delete "num" }}
+                            {{ range (slice 1 2 3 4) }}
+                                {{ $.Scratch.Add "num" (slice (substr $key (sub . 1) 1)) }}
                             {{ end }}
-                            {{ $zodiacName := $.Scratch.Get "zodiacName" }}
-                            {{ $.Scratch.Delete "year" }}
-                            {{ if $.Site.Params.i18nYear }}
-                                {{ $key := .Key }}
-                                {{ $.Scratch.Delete "num" }}
-                                {{ range (slice 1 2 3 4) }}
-                                    {{ $.Scratch.Add "num" (slice (substr $key (sub . 1) 1)) }}
-                                {{ end }}
-                                {{ $num := $.Scratch.Get "num" }}
-                                {{ $.Scratch.Delete "i18nNum" }}
-                                {{ range $num }}
-                                    {{ $.Scratch.Add "i18nNum" (i18n .) }}
-                                {{ end }}
-                                {{ $i18nNum := $.Scratch.Get "i18nNum" }}
-                                {{ $.Scratch.Set "year" $i18nNum }}
-                            {{ else }}
-                                {{ $.Scratch.Set "year" .Key }}
+                            {{ $num := $.Scratch.Get "num" }}
+                            {{ $.Scratch.Delete "i18nNum" }}
+                            {{ range $num }}
+                                {{ $.Scratch.Add "i18nNum" (i18n .) }}
                             {{ end }}
-                            {{ $year := $.Scratch.Get "year" }}
-                            <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ partial "utils/icon.html" (dict "Deliver" $ "name" $zodiacName "class" "chinese-zodiac") }}{{ end }}</h2>
-                            {{ if $.Site.Params.groupByMonth }}
-                                {{ range .Pages.GroupByDate "January" }}
-                                    {{ $.Scratch.Delete "month" }}
-                                    {{ if $.Site.Params.i18nMonth }}
-                                        {{ $month := i18n (lower .Key) }}
-                                        {{ $.Scratch.Set "month" $month }}
-                                    {{ else }}
-                                        {{ $.Scratch.Set "month" .Key }}
-                                    {{ end }}
-                                    {{ $month := $.Scratch.Get "month" }}
-                                    <h3 class="list-month">{{ $month }}</h3>
-                                    {{ partial "utils/list-item.html" (dict "Deliver" .) }}
+                            {{ $i18nNum := $.Scratch.Get "i18nNum" }}
+                            {{ $.Scratch.Set "year" $i18nNum }}
+                        {{ else }}
+                            {{ $.Scratch.Set "year" .Key }}
+                        {{ end }}
+                        {{ $year := $.Scratch.Get "year" }}
+                        <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ partial "utils/icon.html" (dict "Deliver" $ "name" $zodiacName "class" "chinese-zodiac") }}{{ end }}</h2>
+                        {{ if $.Site.Params.groupByMonth }}
+                            {{ range .Pages.GroupByDate "January" }}
+                                {{ $.Scratch.Delete "month" }}
+                                {{ if $.Site.Params.i18nMonth }}
+                                    {{ $month := i18n (lower .Key) }}
+                                    {{ $.Scratch.Set "month" $month }}
+                                {{ else }}
+                                    {{ $.Scratch.Set "month" .Key }}
                                 {{ end }}
-                            {{ else }}
+                                {{ $month := $.Scratch.Get "month" }}
+                                <h3 class="list-month">{{ $month }}</h3>
                                 {{ partial "utils/list-item.html" (dict "Deliver" .) }}
                             {{ end }}
-                        </ul>
+                        {{ else }}
+                            {{ partial "utils/list-item.html" (dict "Deliver" .) }}
+                        {{ end }}
                     {{ end }}
                 </div>
             </div>

--- a/layouts/partials/pages/taxonomy.html
+++ b/layouts/partials/pages/taxonomy.html
@@ -7,18 +7,16 @@
             {{ $type := .Type }}
             {{ range .Data.Terms.ByCount }}
                 {{ $name := .Name }}
-                <ul class="list-part">
-                    <h2 class="term-title">
-                        {{ $page := $.Site.GetPage (printf "/%s/%s" $type $name) }}
-                        {{ with $page }}
-                            <a href="{{ .RelPermalink }}" class="term-title-link">{{ .LinkTitle | default .Data.Term | default $name }}</a>
-                        {{ end }}
-                        {{ if $.Site.Params.displayTaxonomyTermCount }}
-                            <span class="term-count">{{ printf "(%d)" .Count }}</span>
-                        {{ end }}
-                    </h2>
-                    {{ partial "utils/list-item.html" (dict "Deliver" . "linkTarget" $page) }}
-                </ul>
+                <h2 class="term-title">
+                    {{ $page := $.Site.GetPage (printf "/%s/%s" $type $name) }}
+                    {{ with $page }}
+                        <a href="{{ .RelPermalink }}" class="term-title-link">{{ .LinkTitle | default .Data.Term | default $name }}</a>
+                    {{ end }}
+                    {{ if $.Site.Params.displayTaxonomyTermCount }}
+                        <span class="term-count">{{ printf "(%d)" .Count }}</span>
+                    {{ end }}
+                </h2>
+                {{ partial "utils/list-item.html" (dict "Deliver" . "linkTarget" $page) }}
             {{ end }}
         </div>
     </div>

--- a/layouts/partials/utils/list-item.html
+++ b/layouts/partials/utils/list-item.html
@@ -9,16 +9,20 @@
 {{- if ge $limit 0 -}}
     {{- $pages = $pages | first $limit -}}
 {{- end -}}
-{{ range $pages }}
-    <li class="list-item">
-        <a href="{{ .RelPermalink }}" class="list-item-title">{{ .LinkTitle }}</a>
-        <time datetime="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="list-item-time">{{ .PublishDate.Format .Site.Params.listDateFormat }}</time>
-    </li>
-{{ end }}
-{{ if and (gt $limit 0) (gt (len .Deliver.Pages) $limit) }}
-    {{ with $linkTarget }}
-        <li class="list-read-more">
-            <a href="{{ $linkTarget.RelPermalink }}">{{ i18n "readMore" }} »</a>
-        </li>
-    {{ end }}
+{{- with $pages -}}
+    <ul class="list-part">
+        {{ range . }}
+            <li class="list-item">
+                <a href="{{ .RelPermalink }}" class="list-item-title">{{ .LinkTitle }}</a>
+                <time datetime="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="list-item-time">{{ .PublishDate.Format .Site.Params.listDateFormat }}</time>
+            </li>
+        {{ end }}
+        {{ if and (gt $limit 0) (gt (len $.Deliver.Pages) $limit) }}
+            {{ with $linkTarget }}
+                <li class="list-read-more">
+                    <a href="{{ $linkTarget.RelPermalink }}">{{ i18n "readMore" }} »</a>
+                </li>
+            {{ end }}
+        {{ end }}
+    </ul>
 {{ end }}


### PR DESCRIPTION
I made the `list-item.html` template emit the `ul` tag rather than its callers. This has an added bonus: no `<ul>` tag is being emitted now if `limitEntriesLimit` is set to `0` (previously an empty one would be created).