### PR TITLE
Make templates return results properly instead of abusing .Scratch

### DIFF
--- a/layouts/index.sectionsatom.xml
+++ b/layouts/index.sectionsatom.xml
@@ -31,8 +31,7 @@
     <generator uri="https://gohugo.io/" version="{{ hugo.Version }}">Hugo</generator>
     {{- range (where $pages "Section" "in" .Site.Params.mainSections) }}
         {{ $page := . }}
-        {{- partial "utils/author.html" $page -}}
-        {{- $author := ($page.Scratch.Get "author") -}}
+        {{- $author := partial "utils/author.html" $page -}}
         <entry>
             <title type="text">{{ .Title }}</title>
             <link rel="alternate" type="text/html" href="{{ .Permalink }}" />

--- a/layouts/index.sectionsrss.xml
+++ b/layouts/index.sectionsrss.xml
@@ -34,8 +34,7 @@
         {{ end }}
         {{ range (where $pages "Section" "in" .Site.Params.mainSections) }}
             {{ $page := . }}
-            {{- partial "utils/author.html" $page -}}
-            {{- $author := ($page.Scratch.Get "author") -}}
+            {{- $author := partial "utils/author.html" $page -}}
             <item>
                 <title>{{ .Title }}</title>
                 <link>{{ .Permalink }}</link>

--- a/layouts/partials/components/post-copyright.html
+++ b/layouts/partials/components/post-copyright.html
@@ -1,7 +1,6 @@
 {{- $Deliver := . -}}
 {{ if and .Site.Params.enablePostCopyright (.Params.displayCopyright | default .Site.Params.displayPostCopyright) }}
-    {{ partial "utils/author.html" . }}
-    {{ $author := .Scratch.Get "author" }}
+    {{ $author := partial "utils/author.html" . }}
     {{ with $author.name }}
         <ul class="post-copyright">
             <li class="copyright-item author">

--- a/layouts/partials/components/post-copyright.html
+++ b/layouts/partials/components/post-copyright.html
@@ -24,9 +24,7 @@
             {{ end }}
             {{ with $author.copyright }}
                 {{- $raw := . -}}
-                {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
-                {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                <li class="copyright-item license"><span class="copyright-item-text">{{ i18n "copyrightLicense" }}</span>{{ i18n "colon" }}{{ $Content }}</li>
+                <li class="copyright-item license"><span class="copyright-item-text">{{ i18n "copyrightLicense" }}</span>{{ i18n "colon" }}{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</li>
             {{ end }}
         </ul>
     {{ end }}

--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -2,10 +2,9 @@
 
     {{- $description := .Description | default (partial "utils/summary.html" .) | default .Site.Params.siteDescription | plainify -}}
 
-    {{- partial "utils/images.html" . -}}
-    {{- $images := .Scratch.Get "images" -}}
-    {{- $images := .Scratch.Add "images" (slice (.Site.Params.siteLogo | absURL)) -}}
-    {{- $images := (index (.Scratch.Get "images") 0) -}}
+    {{- $images := partial "utils/images.html" . -}}
+    {{- $images = union $images (slice (.Site.Params.siteLogo | absURL)) -}}
+    {{- $images = index $images 0 -}}
 
     {{- $hashtags := newScratch -}}
     {{- with .Params.tags -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -23,23 +23,17 @@
 
             {{- if .Site.Params.displayPoweredBy }}
                 {{- $raw := `Powered by [Hugo](https://github.com/gohugoio/hugo) | Theme is [MemE](https://github.com/reuixiy/hugo-theme-meme)` -}}
-                {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
-                {{- $Content := .Scratch.Get "Content" -}}
-                <div class="powered-by">{{ $Content }}</div>
+                <div class="powered-by">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
             {{- end }}
 
             {{- if .Site.Params.displaySiteCopyright }}
                 {{- $raw := .Site.Copyright -}}
-                {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
-                {{- $Content := .Scratch.Get "Content" -}}
-                <div class="site-copyright">{{ $Content }}</div>
+                <div class="site-copyright">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
             {{- end }}
 
             {{- with .Site.Params.customFooter }}
                 {{- $raw := . -}}
-                {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
-                {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                <div class="custom-footer">{{ $Content }}</div>
+                <div class="custom-footer">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
             {{- end }}
 
             {{- if and .Site.Params.displayBusuanziSiteUVAndPV (eq hugo.Environment "production") }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -60,9 +60,7 @@
     <!-- Avoid Baidu Mobile Search Transcoding -->
     <meta http-equiv="Cache-Control" content="no-siteapp" />
 
-    {{ partial "utils/title.html" . }}
-    {{- $title := .Scratch.Get "title" -}}
-    <title>{{ $title }}</title>
+    <title>{{ (partial "utils/title.html" .).title }}</title>
 
     <!-- CSS -->
     {{- partial "style.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -82,13 +82,9 @@
     {{- $safariMaskIcon := "icons/safari-pinned-tab.svg" -}}
     {{- $safariMaskColor := .Site.Params.safariMaskColor -}}
     {{- $appleTouchIcon := "icons/apple-touch-icon.png" -}}
-    {{- partial "utils/relative-url.html" (dict "Deliver" . "filename" "") -}}
-    {{- $url := .Scratch.Get "url" -}}
-    {{- $msApplicationStartURL := $url -}}
+    {{- $msApplicationStartURL := partial "utils/relative-url.html" (dict "Deliver" . "filename" "") -}}
     {{- $msApplicationTileColor := .Site.Params.msApplicationTileColor -}}
-    {{- partial "utils/relative-url.html" (dict "Deliver" . "filename" "icons/mstile-150x150.png") -}}
-    {{- $url := .Scratch.Get "url" -}}
-    {{- $msApplicationTileImage := $url -}}
+    {{- $msApplicationTileImage := partial "utils/relative-url.html" (dict "Deliver" . "filename" "icons/mstile-150x150.png") -}}
     {{- $manifest := "manifest.json" -}}
     <link rel="shortcut icon" href="{{ $favicon | relURL }}" type="image/x-icon" />
     <link rel="mask-icon" href="{{ $safariMaskIcon | relURL }}" color="{{ $safariMaskColor }}" />

--- a/layouts/partials/pages/home-poetry.html
+++ b/layouts/partials/pages/home-poetry.html
@@ -2,10 +2,7 @@
 <main class="home">
     <div class="poetry">
         {{ range .Site.Params.homePoetry }}
-            {{- $raw := . -}}
-            {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
-            {{- $Content := $Deliver.Scratch.Get "Content" -}}
-            <p>{{ $Content }}</p>
+            <p>{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" . "isContent" false) }}</p>
         {{ end }}
     </div>
     {{ with .Site.Menus.home }}

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -2,21 +2,15 @@
 <main class="main single" id="main">
     <div class="main-inner">
 
-        {{ partial "utils/data-attributes.html" . }}
-        {{- $smallCaps := .Scratch.Get "smallCaps" -}}
-        {{- $align := .Scratch.Get "align" -}}
-        {{- $type := .Scratch.Get "type" -}}
-        {{- $layout := .Scratch.Get "layout" -}}
-        {{- $indent := .Scratch.Get "indent" -}}
-        {{- $tocNum := .Scratch.Get "tocNum" -}}
+        {{ $attrs := partial "utils/data-attributes.html" . }}
 
         <article class="content post"
-        {{- if $smallCaps }} data-small-caps="true"{{ end }}
-        {{- with $align }} data-align="{{ . }}"{{ end }}
-        {{- with $type }} data-type="{{ . }}"{{ end }}
-        {{- with $layout }} data-layout="{{ . }}"{{ end }}
-        {{- if $indent }} data-indent="true"{{ end }}
-        {{- if $tocNum }} data-toc-num="true"{{ end }}>
+        {{- if $attrs.smallCaps }} data-small-caps="true"{{ end }}
+        {{- with $attrs.align }} data-align="{{ . }}"{{ end }}
+        {{- with $attrs.type }} data-type="{{ . }}"{{ end }}
+        {{- with $attrs.layout }} data-layout="{{ . }}"{{ end }}
+        {{- if $attrs.indent }} data-indent="true"{{ end }}
+        {{- if $attrs.tocNum }} data-toc-num="true"{{ end }}>
 
             <h1 class="post-title">{{ .Title }}</h1>
 

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -22,17 +22,13 @@
 
             {{ with .Params.subtitle }}
                 {{- $raw := . -}}
-                {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
-                {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                <div class="post-subtitle">{{ $Content }}</div>
+                <div class="post-subtitle">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
             {{ end }}
 
             {{ if .Site.Params.displayPostDescription }}
                 {{ with .Params.description }}
                     {{- $raw := . -}}
-                    {{- partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) -}}
-                    {{- $Content := $Deliver.Scratch.Get "Content" -}}
-                    <div class="post-description">{{ $Content }}</div>
+                    <div class="post-description">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
                 {{ end }}
             {{ end }}
 
@@ -47,10 +43,8 @@
                 {{ $toc -}}
             {{- end -}}
 
-            {{- partial "utils/content.html" . -}}
-            {{- $Content := .Scratch.Get "Content" -}}
             <div class="post-body">
-                {{- $Content -}}
+              {{ partial "utils/content.html" . }}
             </div>
 
         </article>

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -33,8 +33,6 @@
             {{ $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
             {{- if $enableTOC -}}
                 {{- partial "utils/toc.html" . -}}
-                {{- $toc := .Scratch.Get "toc" }}
-                {{ $toc -}}
             {{- end -}}
 
             <div class="post-body">

--- a/layouts/partials/pages/tree-sections.html
+++ b/layouts/partials/pages/tree-sections.html
@@ -5,8 +5,7 @@
                 <h1 class="list-title">{{ .Title | default (.Type | title) }}</h1>
             {{ end }}
             <div class="tree">
-                {{ partial "utils/tree-sections.html" . }}
-                {{ $pages := (.Scratch.Get "pages") }}
+                {{ $pages := partial "utils/tree-sections.html" . }}
                 {{ range $page, $name := $pages }}
                     {{ $depth := (len (split (strings.TrimPrefix "/" $page) "/")) }}
                     {{ with $.Site.GetPage $page }}

--- a/layouts/partials/pages/tree-sections.html
+++ b/layouts/partials/pages/tree-sections.html
@@ -5,7 +5,8 @@
                 <h1 class="list-title">{{ .Title | default (.Type | title) }}</h1>
             {{ end }}
             <div class="tree">
-                {{ $pages := partial "utils/tree-sections.html" . }}
+                {{ partial "utils/tree-sections.html" . }}
+                {{ $pages := (.Scratch.Get "pages") }}
                 {{ range $page, $name := $pages }}
                     {{ $depth := (len (split (strings.TrimPrefix "/" $page) "/")) }}
                     {{ with $.Site.GetPage $page }}

--- a/layouts/partials/third-party/disqus.html
+++ b/layouts/partials/third-party/disqus.html
@@ -1,5 +1,4 @@
-{{- partial "utils/title.html" . -}}
-{{- $rawTitle := .Scratch.Get "rawTitle" -}}
+{{- $rawTitle := (partial "utils/title.html" .).rawTitle -}}
 <script>
     function loadComments() {
         if (typeof DISQUS === 'undefined') {

--- a/layouts/partials/third-party/service-worker.html
+++ b/layouts/partials/third-party/service-worker.html
@@ -1,6 +1,5 @@
 {{ if and .Site.Params.enableServiceWorker (eq hugo.Environment "production") }}
-    {{- partial "utils/relative-url.html" (dict "Deliver" . "filename" "sw.js") -}}
-    {{- $url := .Scratch.Get "url" }}
+    {{- $url := partial "utils/relative-url.html" (dict "Deliver" . "filename" "sw.js") -}}
 
     <div class="app-refresh" id="app-refresh">
         <div class="app-refresh-wrap" onclick="location.reload()">
@@ -18,7 +17,7 @@
             }
 
             window.addEventListener('load', function() {
-                {{ printf `navigator.serviceWorker.register('%s');` $url | safeJS }}
+                navigator.serviceWorker.register('{{ $url }}');
             });
         }
 

--- a/layouts/partials/utils/author.html
+++ b/layouts/partials/utils/author.html
@@ -1,47 +1,48 @@
-{{- .Scratch.Delete "author" -}}
+{{- $author := dict -}}
 {{- if .Params.original | default .Site.Params.original -}}
     {{- with .Site.Author.name -}}
-        {{- $.Scratch.SetInMap "author" "name" . -}}
+        {{- $author = merge $author (dict "name" .) -}}
     {{- end -}}
     {{- with .Site.Author.email -}}
-        {{- $.Scratch.SetInMap "author" "email" . -}}
+        {{- $author = merge $author (dict "email" .) -}}
     {{- end -}}
     {{- with .Site.Author.motto -}}
-        {{- $.Scratch.SetInMap "author" "motto" . -}}
+        {{- $author = merge $author (dict "motto" .) -}}
     {{- end -}}
     {{- with .Site.Author.avatar -}}
-        {{- $.Scratch.SetInMap "author" "avatar" . -}}
+        {{- $author = merge $author (dict "avatar" .) -}}
     {{- end -}}
     {{- $baseURLWithLangFix := (printf "%s%s/" (strings.TrimSuffix "/" .Site.BaseURL) .Site.LanguagePrefix) -}}
     {{- with .Site.Author.website | default $baseURLWithLangFix -}}
-        {{- $.Scratch.SetInMap "author" "website" . -}}
+        {{- $author = merge $author (dict "website" .) -}}
     {{- end -}}
     {{- with .Site.Copyright -}}
-        {{- $.Scratch.SetInMap "author" "copyright" . -}}
+        {{- $author = merge $author (dict "copyright" .) -}}
     {{- end -}}
     {{- with .Site.Author.twitter -}}
-        {{- $.Scratch.SetInMap "author" "twitter" . -}}
+        {{- $author = merge $author (dict "twitter" .) -}}
     {{- end -}}
 {{- else -}}
     {{- with .Params.author -}}
-        {{- $.Scratch.SetInMap "author" "name" . -}}
+        {{- $author = merge $author (dict "name" .) -}}
     {{- end -}}
     {{- with .Params.email -}}
-        {{- $.Scratch.SetInMap "author" "email" . -}}
+        {{- $author = merge $author (dict "email" .) -}}
     {{- end -}}
     {{- with .Params.motto -}}
-        {{- $.Scratch.SetInMap "author" "motto" . -}}
+        {{- $author = merge $author (dict "motto" .) -}}
     {{- end -}}
     {{- with .Params.avatar -}}
-        {{- $.Scratch.SetInMap "author" "avatar" . -}}
+        {{- $author = merge $author (dict "avatar" .) -}}
     {{- end -}}
     {{- with .Params.website -}}
-        {{- $.Scratch.SetInMap "author" "website" . -}}
+        {{- $author = merge $author (dict "website" .) -}}
     {{- end -}}
     {{- with .Params.copyright -}}
-        {{- $.Scratch.SetInMap "author" "copyright" . -}}
+        {{- $author = merge $author (dict "copyright" .) -}}
     {{- end -}}
     {{- with .Params.twitter -}}
-        {{- $.Scratch.SetInMap "author" "twitter" . -}}
+        {{- $author = merge $author (dict "twitter" .) -}}
     {{- end -}}
 {{- end -}}
+{{- return $author -}}

--- a/layouts/partials/utils/auto-detect-images.html
+++ b/layouts/partials/utils/auto-detect-images.html
@@ -1,29 +1,11 @@
 <!-- https://gohugo.io/functions/findre/ -->
 <!-- https://gohugo.io/functions/replacere/ -->
 <!-- https://regex101.com/ -->
+{{- $imgs := slice -}}
 {{- if and .IsPage (in .Site.Params.mainSections .Section) -}}
-    {{- $imgs := findRE `<img src="/?([^"]+)` .Content | uniq -}}
-    {{- with $imgs -}}
-        {{- $.Scratch.Delete "imgsURL" -}}
-        {{- range . -}}
-            {{- $.Scratch.Delete "replacement" -}}
-            {{- if and $.Site.Params.enableImageHost $.Site.Params.headAlso -}}
-                {{- if (eq hugo.Environment "production") -}}
-                    {{- $url := replaceRE `<img src="/?([^"]+)` `$1` . -}}
-                    {{- if ne (substr $url 0 4) "http" -}}
-                        {{- $hostURL := $.Site.Params.imageHostURL -}}
-                        {{- $replacement := (printf `%s$1` $hostURL) -}}
-                        {{- $.Scratch.Set "replacement" $replacement -}}
-                    {{- else -}}
-                        {{- $.Scratch.Set "replacement" `$1` -}}
-                    {{- end -}}
-                {{- end -}}
-            {{- else -}}
-                {{- $.Scratch.Set "replacement" `$1` -}}
-            {{- end -}}
-            {{- $replacement := $.Scratch.Get "replacement" -}}
-            {{- $imgsURL := replaceRE `<img src="/?([^"]+)` $replacement . -}}
-            {{- $.Scratch.Add "imgsURL" (slice $imgsURL) -}}
-        {{- end -}}
+    {{- range (findRE `<img src="/?([^"]+)` .Content | uniq) -}}
+        {{- $url := replaceRE `<img src="/?([^"]+)` `$1` . -}}
+        {{- $imgs = union $imgs (slice $url) -}}
     {{- end -}}
 {{- end -}}
+{{- return $imgs -}}

--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -1,19 +1,15 @@
 {{- $Deliver := . -}}
-{{- $raw := .Content -}}
-{{- partial "utils/markdownify.html" (dict "Deliver" . "raw" $raw "isContent" true) -}}
+{{- $Content := partial "utils/markdownify.html" (dict "Deliver" . "raw" .Content "isContent" true) -}}
 
 <!-- Link Headings to TOC -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
 {{- if and $enableTOC .Site.Params.linkHeadingsToTOC -}}
     {{- $regexPatternLinkHeadings := `(<h[1-6] id="([^"]+)">)(.+)?(</h[1-6]+>)` -}}
     {{- $regexReplacementLinkHeadings := `$1<a href="#contents:$2" class="headings">$3</a>$4` -}}
-    {{- $Content := $Content | replaceRE $regexPatternLinkHeadings $regexReplacementLinkHeadings | safeHTML -}}
-    {{- .Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | replaceRE $regexPatternLinkHeadings $regexReplacementLinkHeadings -}}
 {{- end -}}
 
 <!-- Headings Anchor -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if .Site.Params.enableHeadingsAnchor -}}
     {{- with .Site.Params.headingsOpt -}}
         {{- $headings := . -}}
@@ -40,12 +36,10 @@
 
     {{- $regexPatternHeadingsAnchor := (printf `(<h[%s] id="([^"]+)">)(.+)?(</h[%s]+>)` $headings $headings) -}}
     {{- $regexReplacementHeadingsAnchor := $replacement -}}
-    {{- $Content := $Content | replaceRE $regexPatternHeadingsAnchor $regexReplacementHeadingsAnchor | safeHTML -}}
-    {{- .Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | replaceRE $regexPatternHeadingsAnchor $regexReplacementHeadingsAnchor -}}
 {{- end -}}
 
 <!-- Drop Cap -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if eq .Type "poetry" -}}
     {{- $enableDropCap := .Params.dropCap | default false -}}
     {{- .Scratch.Set "enableDropCap" $enableDropCap -}}
@@ -59,12 +53,10 @@
     {{- $regexReplacementDropCap := `$1 style="text-indent:0"$2<span class="drop-cap">$3</span>$4` -}}
     {{- $firstParagraphOld := (delimit (findRE $regexPatternDropCap $Content 1) " ") -}}
     {{- $firstParagraphNew := (replaceRE $regexPatternDropCap $regexReplacementDropCap $firstParagraphOld) -}}
-    {{- $Content := replace $Content $firstParagraphOld $firstParagraphNew | safeHTML -}}
-    {{- .Scratch.Set "Content" $Content -}}
+    {{- $Content = replace $Content $firstParagraphOld $firstParagraphNew -}}
 {{- end -}}
 
 <!-- Drop Cap After `<hr />` -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- $enableDropCapAfterHr := .Params.dropCapAfterHr | default .Site.Params.enableDropCapAfterHr -}}
 {{- if ne .Type "poetry" -}}
     {{- if $enableDropCapAfterHr -}}
@@ -79,60 +71,48 @@
 
         {{- $regexPatternDropCapAfterHr := `(\n(<hr />|<hr>))(\n<p)(>)([^<])` -}}
         {{- $regexReplacementDropCapAfterHr := $replacement -}}
-        {{- $Content := $Content | replaceRE $regexPatternDropCapAfterHr $regexReplacementDropCapAfterHr | safeHTML -}}
-        {{- .Scratch.Set "Content" $Content -}}
+        {{- $Content = $Content | replaceRE $regexPatternDropCapAfterHr $regexReplacementDropCapAfterHr -}}
     {{- end -}}
 {{- end -}}
 
 <!-- Footnote Ref with Square Brackets `[]` -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if .Site.Params.squareBrackets -}}
     {{- $regexPatternFootnoteRef := `(<sup id="fnref:\d+"><a href="#fn:\d+"[^>]+>)(\d+)(</a></sup>)` -}}
     {{- $regexReplacementFootnoteRef := `$1[$2]$3` -}}
-    {{- $Content := $Content | replaceRE $regexPatternFootnoteRef $regexReplacementFootnoteRef | safeHTML -}}
-    {{- .Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | replaceRE $regexPatternFootnoteRef $regexReplacementFootnoteRef -}}
 {{- end -}}
 
 <!-- Delete Footnote `<hr />` -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if .Site.Params.insertHrBySelf -}}
     {{- $regexPatternDeleteHr := `(<hr />|<hr>)\n(<section class="footnotes" role="doc-endnotes">)` -}}
     {{- $regexReplacementDeleteHr := `$2` -}}
-    {{- $Content := $Content | replaceRE $regexPatternDeleteHr $regexReplacementDeleteHr | safeHTML -}}
-    {{- .Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | replaceRE $regexPatternDeleteHr $regexReplacementDeleteHr -}}
 {{- end -}}
 
 <!-- Replace `footnoteReturnLinkContents` with icon -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- with .Site.Params.footnoteReturnLinkIcon -}}
     {{- $icon := (partial "utils/icon.html" (dict "Deliver" $ "name" . "class" "footnote-icon")) -}}
     {{- $replacement := (printf `${1}%s$3` $icon) -}}
 
     {{- $regexPatternfootnoteReturnLinkIcon := `(href="#fnref[^>]+>)([^<]+)(.+)` -}}
     {{- $regexReplacementfootnoteReturnLinkIcon := $replacement -}}
-    {{- $Content := $Content | replaceRE $regexPatternfootnoteReturnLinkIcon $regexReplacementfootnoteReturnLinkIcon | safeHTML -}}
-    {{- $.Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | replaceRE $regexPatternfootnoteReturnLinkIcon $regexReplacementfootnoteReturnLinkIcon -}}
 {{- end -}}
 
 <!-- Image & Video Footnote -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- $regexPatternFootnoteImage := `(<sup)(.+</sup><(img|video))` -}}
 {{- $regexReplacementFootnoteImage := `$1 style="float:right"$2` -}}
-{{- $Content := $Content | replaceRE $regexPatternFootnoteImage $regexReplacementFootnoteImage | safeHTML -}}
-{{- .Scratch.Set "Content" $Content -}}
+{{- $Content = $Content | replaceRE $regexPatternFootnoteImage $regexReplacementFootnoteImage -}}
 
 <!-- Image & Video Caption -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if .Site.Params.enableCaption -}}
     {{- $captionPrefix := .Site.Params.captionPrefix -}}
     {{- $regexPatternCaption := `(<(img|video).+) title="([^"]+)"( controls)?( />|>)(</video>)?` -}}
     {{- $regexReplacementCaption := (printf `$1$4$5$6<span class="caption">%s$3</span>` $captionPrefix) -}}
-    {{- $Content := $Content | replaceRE $regexPatternCaption $regexReplacementCaption | safeHTML -}}
-    {{- .Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | replaceRE $regexPatternCaption $regexReplacementCaption -}}
 {{- end -}}
 
 <!-- Image Hosting -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if and .Site.Params.enableImageHost (eq hugo.Environment "production") -}}
     {{- $hostURL := .Site.Params.imageHostURL -}}
     {{- $temps := findRE `<(img) src="/?([^":]+)` $Content | uniq -}}
@@ -142,15 +122,13 @@
                 {{- $url := replaceRE `<(img) src="/?([^":]+)` `$2` . -}}
                 {{- $prefix := replaceRE `(<(img) src=")/?([^":]+)` `$1` . -}}
                 {{- $replacement := (printf `%s%s%s` $prefix $hostURL $url) -}}
-                {{- $Content := replace ($.Scratch.Get "Content") . $replacement | safeHTML -}}
-                {{- $.Scratch.Set "Content" $Content -}}
+                {{- $Content = replace $Content . $replacement -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}
 
 <!-- Video Hosting -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if and .Site.Params.enableVideoHost (eq hugo.Environment "production") -}}
     {{- $hostURL := .Site.Params.videoHostURL -}}
     {{- $temps := findRE `<(video) src="/?([^":]+)` $Content | uniq -}}
@@ -160,27 +138,23 @@
                 {{- $url := replaceRE `<(video) src="/?([^":]+)` `$2` . -}}
                 {{- $prefix := replaceRE `(<(video) src=")/?([^":]+)` `$1` . -}}
                 {{- $replacement := (printf `%s%s%s` $prefix $hostURL $url) -}}
-                {{- $Content := replace ($.Scratch.Get "Content") . $replacement | safeHTML -}}
-                {{- $.Scratch.Set "Content" $Content -}}
+                {{- $Content = replace $Content . $replacement -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}
 
 <!-- Paragraph Indent -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- $enableIndent := (and .Site.Params.enableParagraphIndent .Params.indent) | default (and .Site.Params.enableParagraphIndent (eq .Site.Params.paragraphStyle "indent")) -}}
 {{- if ne .Type "poetry" -}}
     {{- if $enableIndent -}}
         {{- $regexPatternIndent := `((</p>|<blockquote>)\n<p)(>)(.+(<br />|<br>))` -}}
         {{- $regexReplacementIndent := `$1 style="text-indent:0;padding-left:2em;margin:1em 0"$3$4` -}}
-        {{- $Content := $Content | replaceRE $regexPatternIndent $regexReplacementIndent | safeHTML -}}
-        {{- .Scratch.Set "Content" $Content -}}
+        {{- $Content = $Content | replaceRE $regexPatternIndent $regexReplacementIndent -}}
     {{- end -}}
 {{- end -}}
 
 <!-- Do NOT Indent The First Paragraph -->
-{{- $Content := .Scratch.Get "Content" -}}
 {{- if and (not (.Params.indentFirstParagraph | default .Site.Params.indentFirstParagraph)) $enableIndent -}}
     {{- if ne .Type "poetry" -}}
         {{- if not $enableDropCap -}}
@@ -188,10 +162,8 @@
             {{- $replacement := `$1 style="text-indent:0"$2` -}}
             {{- $firstParagraphOld := (delimit (findRE $regex $Content 1) " ") -}}
             {{- $firstParagraphNew := (replaceRE $regex $replacement $firstParagraphOld) -}}
-            {{- $Content := replace $Content $firstParagraphOld $firstParagraphNew | safeHTML -}}
-            {{- .Scratch.Set "Content" $Content -}}
+            {{- $Content = replace $Content $firstParagraphOld $firstParagraphNew -}}
         {{- end -}}
-        {{- $Content := .Scratch.Get "Content" -}}
         {{- if not $enableDropCapAfterHr -}}
             {{- $regex := `((</h[1-6]>|<hr>|<hr />)\n(<blockquote>\n)?<p)(>[^<])` -}}
             {{- $.Scratch.Set "regex" $regex -}}
@@ -201,19 +173,16 @@
         {{- end -}}
         {{- $regex := .Scratch.Get "regex" -}}
         {{- $replacement := `$1 style="text-indent:0"$4` -}}
-        {{- $Content := $Content | replaceRE $regex $replacement | safeHTML -}}
-        {{- .Scratch.Set "Content" $Content -}}
+        {{- $Content = $Content | replaceRE $regex $replacement -}}
     {{- end -}}
 {{- end -}}
 
 <!-- Dark Mode -->
 {{- if .Site.Params.enableHighlight -}}
     {{- if and .Site.Params.enableDarkMode (eq .Site.Params.defaultTheme "dark") -}}
-        {{- $Content := .Scratch.Get "Content" -}}
         {{- $regexPatternDarkmode := `(<(div|pre) class=")chroma(">)` -}}
         {{- $regexReplacementDarkmode := `${1}chroma-dark${3}` -}}
-        {{- $Content := $Content | replaceRE $regexPatternDarkmode $regexReplacementDarkmode | safeHTML -}}
-        {{- .Scratch.Set "Content" $Content -}}
+        {{- $Content = $Content | replaceRE $regexPatternDarkmode $regexReplacementDarkmode -}}
     {{- end -}}
 {{- end -}}
 
@@ -221,5 +190,4 @@
 {{- partial "custom/content.html" . -}}
 
 <!-- Final Content -->
-{{- $Content := .Scratch.Get "Content" -}}
-{{- .Scratch.Set "Content" $Content -}}
+{{- $Content | safeHTML -}}

--- a/layouts/partials/utils/data-attributes.html
+++ b/layouts/partials/utils/data-attributes.html
@@ -1,44 +1,29 @@
 <!-- Small Caps -->
-{{- .Scratch.Delete "smallCaps" -}}
-{{- if .Params.smallCaps | default .Site.Params.enableSmallCaps -}}
-    {{- .Scratch.Set "smallCaps" true -}}
-{{- end -}}
+{{- $smallCaps := .Params.smallCaps | default .Site.Params.enableSmallCaps | default false -}}
 
 <!-- Align -->
-{{- .Scratch.Delete "align" -}}
-{{- with .Params.align | default "default" -}}
-    {{- if ne $.Type "poetry" -}}
-        {{- if or (eq . "justify") (and $.Site.Params.enableJustify (eq . "default")) -}}
-            {{- $.Scratch.Set "align" "justify" -}}
-        {{- end -}}
-    {{- end -}}
-    {{- if eq . "center" -}}
-        {{- $.Scratch.Set "align" "center" -}}
+{{- $align := .Params.align | default "default" -}}
+{{- if ne .Type "poetry" -}}
+    {{- if and $.Site.Params.enableJustify (eq $align "default") -}}
+        {{- $align = "justify" -}}
     {{- end -}}
 {{- end -}}
 
 <!-- Type -->
-{{- .Scratch.Delete "type" -}}
-{{- with .Type -}}
-    {{- $.Scratch.Set "type" . -}}
-{{- end -}}
+{{- $type := .Type -}}
 
 <!-- Layout -->
-{{- .Scratch.Delete "layout" -}}
-{{- with .Params.layout -}}
-    {{- $.Scratch.Set "layout" . -}}
-{{- end -}}
+{{- $layout := .Params.layout -}}
 
 <!-- Paragraph Indent -->
-{{- .Scratch.Delete "indent" -}}
-{{- if ne .Type "poetry" -}}
-    {{- if (and .Site.Params.enableParagraphIndent .Params.indent) | default (and .Site.Params.enableParagraphIndent (eq .Site.Params.paragraphStyle "indent")) -}}
-        {{- .Scratch.Set "indent" true -}}
+{{- $indent := false -}}
+{{- if and .Site.Params.enableParagraphIndent (ne .Type "poetry") -}}
+    {{- if or .Params.indent (eq .Site.Params.paragraphStyle "indent") -}}
+        {{- $indent = true -}}
     {{- end -}}
 {{- end -}}
 
 <!-- TOC Number -->
-{{- .Scratch.Delete "tocNum" -}}
-{{- with .Params.tocNum | default .Site.Params.displayTOCNum -}}
-    {{- $.Scratch.Set "tocNum" . -}}
-{{- end -}}
+{{- $tocNum := .Params.tocNum | default .Site.Params.displayTOCNum -}}
+
+{{- return dict "smallCaps" $smallCaps "align" $align "type" $type "layout" $layout "indent" $indent "tocNum" $tocNum -}}

--- a/layouts/partials/utils/date.html
+++ b/layouts/partials/utils/date.html
@@ -1,16 +1,13 @@
-{{- $.Scratch.Delete "pubDate" -}}
-{{- if .PublishDate.IsZero -}}
-    {{- $pubDate := dateFormat "2006-01-02T15:04:05-07:00" (time .Site.Params.siteCreatedTime) -}}
-    {{- $.Scratch.Set "pubDate" $pubDate -}}
-{{- else -}}
-    {{- $pubDate := .PublishDate.Format "2006-01-02T15:04:05-07:00" -}}
-    {{- $.Scratch.Set "pubDate" $pubDate -}}
+{{- $pubDate := .PublishDate -}}
+{{- if $pubDate.IsZero -}}
+    {{- $pubDate = .Site.Params.siteCreatedTime -}}
 {{- end -}}
-{{- $.Scratch.Delete "modDate" -}}
-{{- if .Lastmod.IsZero -}}
-    {{- $modDate := dateFormat "2006-01-02T15:04:05-07:00" (time .Site.Params.siteCreatedTime) -}}
-    {{- $.Scratch.Set "modDate" $modDate -}}
-{{- else -}}
-    {{- $modDate := .Lastmod.Format "2006-01-02T15:04:05-07:00" -}}
-    {{- $.Scratch.Set "modDate" $modDate -}}
+{{- $pubDate = dateFormat "2006-01-02T15:04:05-07:00" $pubDate -}}
+
+{{- $modDate := .Lastmod -}}
+{{- if $modDate.IsZero -}}
+    {{- $modDate = .Site.Params.siteCreatedTime -}}
 {{- end -}}
+{{- $modDate = dateFormat "2006-01-02T15:04:05-07:00" $modDate -}}
+
+{{- return dict "pubDate" $pubDate "modDate" $modDate -}}

--- a/layouts/partials/utils/images.html
+++ b/layouts/partials/utils/images.html
@@ -1,34 +1,28 @@
-<!-- Auto Detect Images -->
-{{- if .Site.Params.autoDetectImages -}}
-    {{- partial "utils/auto-detect-images.html" . -}}
-{{- end -}}
-{{- $imgsURL := .Scratch.Get "imgsURL" -}}
+{{- $imgs := .Params.images -}}
 
-<!-- Image Hosting -->
-{{- .Scratch.Delete "imagesParam" -}}
-{{- with .Params.images -}}
-    {{- if and $.Site.Params.enableImageHost $.Site.Params.headAlso -}}
-        {{- if (eq hugo.Environment "production") -}}
-            {{- range . -}}
+<!-- Auto Detect Images -->
+{{- if and (not $imgs) .Site.Params.autoDetectImages -}}
+    {{- $imgs = partial "utils/auto-detect-images.html" . -}}
+{{- end -}}
+
+{{- with $imgs -}}
+    {{- $translated := slice -}}
+    {{- range $index, $img := $imgs -}}
+        <!-- Image Hosting -->
+        {{- if and $.Site.Params.enableImageHost $.Site.Params.headAlso -}}
+            {{- if (eq hugo.Environment "production") -}}
                 {{- if ne (substr . 0 4) "http" -}}
-                    {{- $image := printf `%s%s` $.Site.Params.imageHostURL (strings.TrimPrefix "/" .) -}}
-                    {{- $.Scratch.Add "imagesParam" (slice $image) -}}
-                {{- else -}}
-                    {{- $.Scratch.Add "imagesParam" (slice .) -}}
+                    {{- $img = printf `%s%s` $.Site.Params.imageHostURL (strings.TrimPrefix "/" $img) -}}
                 {{- end -}}
             {{- end -}}
         {{- end -}}
-    {{- else -}}
-        {{- $.Scratch.Set "imagesParam" . -}}
-    {{- end -}}
-{{- end -}}
-{{- $imagesParam := .Scratch.Get "imagesParam" -}}
 
-<!-- Image absURL -->
-{{- .Scratch.Delete "images" -}}
-{{- with $imagesParam | default $imgsURL -}}
-    {{- range . -}}
-        {{- $image := . | absURL -}}
-        {{- $.Scratch.Add "images" (slice $image) -}}
+        <!-- Make URLs absolute -->
+        {{- $img = $img | absURL -}}
+
+        {{- $translated = union $translated (slice $img) -}}
     {{- end -}}
+    {{- $imgs = $translated -}}
 {{- end -}}
+
+{{- return $imgs -}}

--- a/layouts/partials/utils/json-ld.html
+++ b/layouts/partials/utils/json-ld.html
@@ -14,8 +14,7 @@
 <!-- Author -->
 {{- $author := partial "utils/author.html" $Deliver -}}
 <!-- Images -->
-{{- partial "utils/images.html" $Deliver -}}
-{{- $images := $Deliver.Scratch.Get "images" -}}
+{{- $images := partial "utils/images.html" $Deliver -}}
 
 {{- if $Deliver.IsHome -}}
 <script type="application/ld+json">

--- a/layouts/partials/utils/json-ld.html
+++ b/layouts/partials/utils/json-ld.html
@@ -8,9 +8,7 @@
 {{- partial "utils/title.html" $Deliver -}}
 {{- $rawTitle := $Deliver.Scratch.Get "rawTitle" -}}
 <!-- Date -->
-{{- partial "utils/date.html" $Deliver -}}
-{{- $pubDate := $Deliver.Scratch.Get "pubDate" -}}
-{{- $modDate := $Deliver.Scratch.Get "modDate" -}}
+{{- $dates := partial "utils/date.html" $Deliver -}}
 <!-- Author -->
 {{- $author := partial "utils/author.html" $Deliver -}}
 <!-- Images -->
@@ -21,8 +19,8 @@
     {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "datePublished": {{ $pubDate }},
-        "dateModified": {{ $modDate }},
+        "datePublished": {{ $dates.pubDate }},
+        "dateModified": {{ $dates.modDate }},
         "url": {{ $baseURLWithLangFix }},
         "description": {{ $description }},
         {{ with $Deliver.Site.Params.siteLogo -}}
@@ -59,8 +57,8 @@
     {
         "@context": "https://schema.org",
         "@type": "BlogPosting",
-        "datePublished": {{ $pubDate }},
-        "dateModified": {{ $modDate }},
+        "datePublished": {{ $dates.pubDate }},
+        "dateModified": {{ $dates.modDate }},
         "url": {{ $Deliver.Permalink }},
         "headline": {{ $rawTitle }},
         "description": {{ $description }},
@@ -119,8 +117,8 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "datePublished": {{ $pubDate }},
-        "dateModified": {{ $modDate }},
+        "datePublished": {{ $dates.pubDate }},
+        "dateModified": {{ $dates.modDate }},
         "url": {{ $Deliver.Permalink }},
         "name": {{ $rawTitle }},
         "description": {{ $description }},

--- a/layouts/partials/utils/json-ld.html
+++ b/layouts/partials/utils/json-ld.html
@@ -12,8 +12,7 @@
 {{- $pubDate := $Deliver.Scratch.Get "pubDate" -}}
 {{- $modDate := $Deliver.Scratch.Get "modDate" -}}
 <!-- Author -->
-{{- partial "utils/author.html" $Deliver -}}
-{{- $author := $Deliver.Scratch.Get "author" -}}
+{{- $author := partial "utils/author.html" $Deliver -}}
 <!-- Images -->
 {{- partial "utils/images.html" $Deliver -}}
 {{- $images := $Deliver.Scratch.Get "images" -}}

--- a/layouts/partials/utils/json-ld.html
+++ b/layouts/partials/utils/json-ld.html
@@ -5,8 +5,7 @@
 {{- $description := .description -}}
 {{- $baseURLWithLangFix := print `/` | absLangURL -}}
 <!-- Title -->
-{{- partial "utils/title.html" $Deliver -}}
-{{- $rawTitle := $Deliver.Scratch.Get "rawTitle" -}}
+{{- $rawTitle := (partial "utils/title.html" $Deliver).rawTitle -}}
 <!-- Date -->
 {{- $dates := partial "utils/date.html" $Deliver -}}
 <!-- Author -->

--- a/layouts/partials/utils/markdownify.html
+++ b/layouts/partials/utils/markdownify.html
@@ -1,47 +1,30 @@
 {{- $Deliver := .Deliver -}}
-{{- $raw := .raw -}}
+{{- $Content := .raw -}}
 {{- $isContent := .isContent -}}
 
-{{- $Deliver.Scratch.Set "Content" $raw -}}
-
 <!-- New Markdown Syntax: Emphasis Point `..text..` -->
-{{- $Content := $Deliver.Scratch.Get "Content" -}}
 {{- if $Deliver.Site.Params.enableEmphasisPoint -}}
     {{- $regexPatternEmphasisPoint := `([^\.\x60])\.\.([^\.\s\n\/\\]+)\.\.([^\.\x60])` -}}
     {{- $regexReplacementEmphasisPoint := `$1<em class="emphasis-point">$2</em>$3` -}}
-    {{- $Content := $Content | replaceRE $regexPatternEmphasisPoint $regexReplacementEmphasisPoint | safeHTML -}}
-    {{- $Deliver.Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | replaceRE $regexPatternEmphasisPoint $regexReplacementEmphasisPoint -}}
 {{- end -}}
 
 <!-- Markdownify -->
-{{- $Content := $Deliver.Scratch.Get "Content" -}}
 {{- if not $isContent -}}
-    {{- $Content := $Content | markdownify -}}
-    {{- $Deliver.Scratch.Set "Content" $Content -}}
+    {{- $Content = $Content | markdownify -}}
 
     <!-- Emojify -->
     {{- if (fileExists "config.toml") -}}
         {{- $enableEmoji := replaceRE `enableEmoji = (.+)` `$1` (delimit (readFile "config.toml" | findRE `enableEmoji = (.+)` | uniq) " ") -}}
         {{- if eq $enableEmoji "true" -}}
-            {{- $Content := $Deliver.Scratch.Get "Content" -}}
-            {{- $Content := $Content | emojify -}}
-            {{- $Deliver.Scratch.Set "Content" $Content -}}
+            {{- $Content = $Content | emojify -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}
 
 <!-- External Links -->
-{{- $Content := $Deliver.Scratch.Get "Content" -}}
 {{- if $Deliver.Site.Params.hrefTargetBlank -}}
-    {{- $temps := findRE `(<a href="[^"]+")` $Content | uniq -}}
-    {{- with $temps -}}
-        {{- range . -}}
-            {{- if eq (substr . 9 4) "http" -}}
-                {{- $raw := replaceRE `(<a href="[^"]+")` `$1` . -}}
-                {{- $replacement := printf `%s target="_blank" rel="noopener"` $raw -}}
-                {{- $Content := replace ($Deliver.Scratch.Get "Content") . $replacement | safeHTML -}}
-                {{- $Deliver.Scratch.Set "Content" $Content -}}
-            {{- end -}}
-        {{- end -}}
-    {{- end -}}
+    {{- $Content = replaceRE `(<a href="https?:[^"]+")` `$1 target="_blank" rel="noopener"` $Content -}}
 {{- end -}}
+
+{{- $Content | safeHTML -}}

--- a/layouts/partials/utils/open-graph.html
+++ b/layouts/partials/utils/open-graph.html
@@ -13,8 +13,7 @@
 {{- $pubDate := $Deliver.Scratch.Get "pubDate" -}}
 {{- $modDate := $Deliver.Scratch.Get "modDate" -}}
 <!-- Images -->
-{{- partial "utils/images.html" $Deliver -}}
-{{- $images := $Deliver.Scratch.Get "images" -}}
+{{- $images := partial "utils/images.html" $Deliver -}}
 
 <meta property="og:title" content="{{ $rawTitle }}" />
 <meta property="og:description" content="{{ $description }}" />

--- a/layouts/partials/utils/open-graph.html
+++ b/layouts/partials/utils/open-graph.html
@@ -9,9 +9,7 @@
 {{- partial "utils/title.html" $Deliver -}}
 {{- $rawTitle := $Deliver.Scratch.Get "rawTitle" -}}
 <!-- Date -->
-{{- partial "utils/date.html" $Deliver -}}
-{{- $pubDate := $Deliver.Scratch.Get "pubDate" -}}
-{{- $modDate := $Deliver.Scratch.Get "modDate" -}}
+{{- $dates := partial "utils/date.html" $Deliver -}}
 <!-- Images -->
 {{- $images := partial "utils/images.html" $Deliver -}}
 
@@ -38,8 +36,8 @@
 
 {{- if and $Deliver.IsPage (in $Deliver.Site.Params.mainSections $Deliver.Section) -}}
     <meta property="og:type" content="article" />
-    <meta property="article:published_time" content="{{ $pubDate }}" />
-    <meta property="article:modified_time" content="{{ $modDate }}" />
+    <meta property="article:published_time" content="{{ $dates.pubDate }}" />
+    <meta property="article:modified_time" content="{{ $dates.modDate }}" />
     {{ if not $Deliver.ExpiryDate.IsZero -}}
         <meta property="article:expiration_time" content="{{ $Deliver.ExpiryDate.Format "2006-01-02T15:04:05-07:00" }}" />
     {{- end }}

--- a/layouts/partials/utils/open-graph.html
+++ b/layouts/partials/utils/open-graph.html
@@ -5,15 +5,12 @@
 <!-- https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/opengraph.html -->
 {{- $Deliver := .Deliver -}}
 {{- $description := .description -}}
-<!-- Title -->
-{{- partial "utils/title.html" $Deliver -}}
-{{- $rawTitle := $Deliver.Scratch.Get "rawTitle" -}}
 <!-- Date -->
 {{- $dates := partial "utils/date.html" $Deliver -}}
 <!-- Images -->
 {{- $images := partial "utils/images.html" $Deliver -}}
 
-<meta property="og:title" content="{{ $rawTitle }}" />
+<meta property="og:title" content="{{ (partial "utils/title.html" $Deliver).rawTitle }}" />
 <meta property="og:description" content="{{ $description }}" />
 <meta property="og:url" content="{{ $Deliver.Permalink }}" />
 <meta property="og:site_name" content="{{ $Deliver.Site.Title }}" />

--- a/layouts/partials/utils/open-graph.html
+++ b/layouts/partials/utils/open-graph.html
@@ -12,9 +12,6 @@
 {{- partial "utils/date.html" $Deliver -}}
 {{- $pubDate := $Deliver.Scratch.Get "pubDate" -}}
 {{- $modDate := $Deliver.Scratch.Get "modDate" -}}
-<!-- Author -->
-{{- partial "utils/author.html" $Deliver -}}
-{{- $author := $Deliver.Scratch.Get "author" -}}
 <!-- Images -->
 {{- partial "utils/images.html" $Deliver -}}
 {{- $images := $Deliver.Scratch.Get "images" -}}

--- a/layouts/partials/utils/relative-url.html
+++ b/layouts/partials/utils/relative-url.html
@@ -1,20 +1,12 @@
 {{- $Deliver := .Deliver -}}
 {{- $filename := .filename -}}
 
-{{- $url := $Deliver.RelPermalink -}}
-{{- $depth := (len (split (strings.TrimSuffix "/" $url) "/")) -}}
-
-{{- if eq $depth 1 -}}
-    {{- $url := printf "./%s" $filename -}}
-    {{- $Deliver.Scratch.Set "url" $url -}}
-{{- else -}}
-    {{- $Deliver.Scratch.Set "level" "" -}}
-    {{- range $index, $value := (split (strings.TrimSuffix "/" $url) "/") -}}
-        {{- if lt $index (sub $depth 1) -}}
-            {{- $level := printf `../%s` ($Deliver.Scratch.Get "level") -}}
-            {{- $Deliver.Scratch.Set "level" $level -}}
-            {{- $url := printf `%s%s` $level $filename -}}
-            {{- $Deliver.Scratch.Set "url" $url -}}
-        {{- end -}}
+{{- $url := $filename -}}
+{{- $pathParts := split ($Deliver.RelPermalink | strings.TrimPrefix "/" | strings.TrimSuffix "/") "/" -}}
+{{- range $pathParts -}}
+    {{- with . -}}
+        {{- $url = printf `../%s` $url -}}
     {{- end -}}
 {{- end -}}
+
+{{- return $url -}}

--- a/layouts/partials/utils/title.html
+++ b/layouts/partials/utils/title.html
@@ -1,33 +1,27 @@
 <!-- Home -->
+{{- $rawTitle := .Title -}}
 {{- if eq .Kind "home" -}}
-    {{- $title := .Title | default .Site.Title -}}
-    {{- .Scratch.Set "rawTitle" $title -}}
-    {{- .Scratch.Set "title" $title -}}
+    {{- $rawTitle = $rawTitle | default .Site.Title -}}
 <!-- Taxonomy -->
 {{- else if eq .Kind "taxonomyTerm" -}}
-    {{- $rawTitle := (.Title | default (.Type | title)) -}}
-    {{- $title := printf "%s | %s" $rawTitle .Site.Title -}}
-    {{- .Scratch.Set "rawTitle" $rawTitle -}}
-    {{- .Scratch.Set "title" $title -}}
+    {{- $rawTitle = $rawTitle | default (.Type | title) -}}
 <!-- Taxonomy Term -->
 {{- else if eq .Kind "taxonomy" -}}
-    {{- $taxonomyTermTitle := .Title | default .Data.Term | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" .Path) "/")) " ") -}}
+    {{- $taxonomyTermTitle := $rawTitle | default .Data.Term | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" .Path) "/")) " ") -}}
     {{- with .Site.GetPage (printf "/%s" .Data.Plural) -}}
-        {{- $rawTitle := printf "%s: %s" (.Title | default (.Type | title)) $taxonomyTermTitle -}}
-        {{- $title := printf "%s | %s" $rawTitle .Site.Title -}}
-        {{- $.Scratch.Set "rawTitle" $rawTitle -}}
-        {{- $.Scratch.Set "title" $title -}}
+        {{- $rawTitle = printf "%s: %s" (.Title | default (.Type | title)) $taxonomyTermTitle -}}
     {{- end -}}
 <!-- Section -->
 {{- else if eq .Kind "section" -}}
-    {{- $rawTitle := .Title | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" .Path) "/")) " ") | plainify -}}
-    {{- $title := printf "%s | %s" $rawTitle .Site.Title -}}
-    {{- .Scratch.Set "rawTitle" $rawTitle -}}
-    {{- .Scratch.Set "title" $title -}}
+    {{- $rawTitle = $rawTitle | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" .Path) "/")) " ") | plainify -}}
 <!-- Page -->
 {{- else -}}
-    {{- $rawTitle := .Title | plainify -}}
-    {{- $title := printf "%s | %s" $rawTitle .Site.Title -}}
-    {{- .Scratch.Set "rawTitle" $rawTitle -}}
-    {{- .Scratch.Set "title" $title -}}
+    {{- $rawTitle = $rawTitle | plainify -}}
 {{- end -}}
+
+{{- $title := $rawTitle -}}
+{{- if ne .Kind "home" -}}
+    {{- $title = printf "%s | %s" $title .Site.Title -}}
+{{- end -}}
+
+{{- return dict "rawTitle" $rawTitle "title" $title -}}

--- a/layouts/partials/utils/toc.html
+++ b/layouts/partials/utils/toc.html
@@ -3,29 +3,25 @@
 <!-- Change TOC Attribute -->
 {{- $regexPatternTOC := `<nav id="TableOfContents">` -}}
 {{- $regexReplacementTOC := `<nav class="contents">` -}}
-{{- $toc := $toc | replaceRE $regexPatternTOC $regexReplacementTOC | safeHTML -}}
+{{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
 
 <!-- Inject Class Attribute -->
 {{- $regexPatternTOC := `(<nav class="contents">\n.+)<(ol|ul)>` -}}
 {{- $regexReplacementTOC := `$1<$2 class="toc">` -}}
-{{- $toc := $toc | replaceRE $regexPatternTOC $regexReplacementTOC | safeHTML -}}
+{{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
 
 <!-- Inject TOC Title -->
 {{- if .Site.Params.displayTOCTitle -}}
     {{- $regexPatternTOC := `(<nav class="contents">\n.+)(<(ol|ul) class="toc">)` -}}
     {{- $regexReplacementTOC := (printf `$1<h2 id="contents" class="contents-title">%s</h2>$2` (i18n "tocTitle")) -}}
-    {{- $toc := $toc | replaceRE $regexPatternTOC $regexReplacementTOC | safeHTML -}}
-    {{- .Scratch.Set "toc" $toc -}}
+    {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
 {{- end -}}
 
 <!-- Link Headings to TOC -->
-{{- $toc := .Scratch.Get "toc" | default $toc -}}
 {{- if .Site.Params.linkHeadingsToTOC -}}
     {{- $regexPatternTOC := `(<a)( href="#([^"]+)">)` -}}
     {{- $regexReplacementTOC := `$1 id="contents:$3"$2` -}}
-    {{- $toc := $toc | replaceRE $regexPatternTOC $regexReplacementTOC | safeHTML -}}
-    {{- .Scratch.Set "toc" $toc -}}
+    {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
 {{ end }}
 
-{{- $toc := .Scratch.Get "toc" | default $toc -}}
-{{- .Scratch.Set "toc" $toc -}}
+{{- $toc | safeHTML -}}

--- a/layouts/partials/utils/tree-sections.html
+++ b/layouts/partials/utils/tree-sections.html
@@ -1,9 +1,9 @@
 <!-- Nested / Iteration / Recursion -->
-{{- $.Scratch.Delete "sections" -}}
-{{- $.Scratch.Delete "pages" -}}
 {{- $Deliver := . -}}
 {{- $contentDir := $.Site.Params.contentDir -}}
-{{- template "treeSections" (dict "Deliver" $Deliver "path" (cond $.Site.IsMultiLingual (printf `./%s` $contentDir) (printf `./content`))) -}}
+{{- $pages := dict -}}
+{{- template "treeSections" (dict "Deliver" $Deliver "path" (cond $.Site.IsMultiLingual $contentDir `content`)) -}}
+
 {{- define "treeSections" -}}
     {{- $Deliver := .Deliver -}}
     {{- $path := .path -}}
@@ -13,11 +13,12 @@
             {{- $pagePath := (cond $Deliver.Site.IsMultiLingual (strings.TrimPrefix (printf `./%s` $Deliver.Site.Params.contentDir) (printf `%s/%s` $path $fileName)) (strings.TrimPrefix "./content" (printf `%s/%s` $path $fileName))) -}}
             {{- with $Deliver.Site.GetPage $pagePath -}}
                 {{- if and (eq .Kind "section") (in $Deliver.Site.Params.mainSections .Section) -}}
-                    {{- $Deliver.Scratch.Add "sections" (printf "%s, " $fileName) -}}
-                    {{- $Deliver.Scratch.SetInMap "pages" $pagePath $fileName -}}
+                    {{- $pages = merge $pages (dict $pagePath $fileName) -}}
                 {{- end -}}
             {{- end -}}
             {{- template "treeSections" (dict "Deliver" $Deliver "path" (printf `%s/%s` $path $fileName)) -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}
+
+{{- return $pages -}}

--- a/layouts/partials/utils/tree-sections.html
+++ b/layouts/partials/utils/tree-sections.html
@@ -1,9 +1,9 @@
 <!-- Nested / Iteration / Recursion -->
+{{- $.Scratch.Delete "sections" -}}
+{{- $.Scratch.Delete "pages" -}}
 {{- $Deliver := . -}}
 {{- $contentDir := $.Site.Params.contentDir -}}
-{{- $pages := dict -}}
-{{- template "treeSections" (dict "Deliver" $Deliver "path" (cond $.Site.IsMultiLingual $contentDir `content`)) -}}
-
+{{- template "treeSections" (dict "Deliver" $Deliver "path" (cond $.Site.IsMultiLingual (printf `./%s` $contentDir) (printf `./content`))) -}}
 {{- define "treeSections" -}}
     {{- $Deliver := .Deliver -}}
     {{- $path := .path -}}
@@ -13,12 +13,11 @@
             {{- $pagePath := (cond $Deliver.Site.IsMultiLingual (strings.TrimPrefix (printf `./%s` $Deliver.Site.Params.contentDir) (printf `%s/%s` $path $fileName)) (strings.TrimPrefix "./content" (printf `%s/%s` $path $fileName))) -}}
             {{- with $Deliver.Site.GetPage $pagePath -}}
                 {{- if and (eq .Kind "section") (in $Deliver.Site.Params.mainSections .Section) -}}
-                    {{- $pages = merge $pages (dict $pagePath $fileName) -}}
+                    {{- $Deliver.Scratch.Add "sections" (printf "%s, " $fileName) -}}
+                    {{- $Deliver.Scratch.SetInMap "pages" $pagePath $fileName -}}
                 {{- end -}}
             {{- end -}}
             {{- template "treeSections" (dict "Deliver" $Deliver "path" (printf `%s/%s` $path $fileName)) -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}
-
-{{- return $pages -}}

--- a/layouts/partials/utils/twitter-cards.html
+++ b/layouts/partials/utils/twitter-cards.html
@@ -3,8 +3,7 @@
 <!-- https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/twitter_cards.html -->
 {{- $Deliver := .Deliver -}}
 <!-- Author -->
-{{- partial "utils/author.html" $Deliver -}}
-{{- $author := $Deliver.Scratch.Get "author" -}}
+{{- $author := partial "utils/author.html" $Deliver -}}
 <!-- Images -->
 {{- partial "utils/images.html" $Deliver -}}
 {{- $images := $Deliver.Scratch.Get "images" -}}

--- a/layouts/partials/utils/twitter-cards.html
+++ b/layouts/partials/utils/twitter-cards.html
@@ -5,8 +5,7 @@
 <!-- Author -->
 {{- $author := partial "utils/author.html" $Deliver -}}
 <!-- Images -->
-{{- partial "utils/images.html" $Deliver -}}
-{{- $images := $Deliver.Scratch.Get "images" -}}
+{{- $images := partial "utils/images.html" $Deliver -}}
 
 {{- with $images -}}
     <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
The initial commit fixes #137. I also could fail to notice that `hrefTargetBlank` processing in `markdownify.html` seems very inefficient - let me know if I missed something that the original code was doing better.

I must say that I didn't test the changes to `content.html` fully - it's way too many branches and settings. But the changes are pretty straightforward.

I want to add more commits to this pull request, there are other templates following the same pattern.