### PR TITLE
fix: When scrolling to an anchor, account for the header height (fixes #146)

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -18,6 +18,16 @@ if (mainInner !== null) {
 headerInner.style.setProperty('opacity', 1);
 
 
+// Measure header height for the scrolling fix
+{
+    const header = document.querySelector('.header');
+    if (header) {
+        const headerHeight = window.getComputedStyle(header, null).getPropertyValue('height');
+        document.documentElement.style.setProperty('--header-height', headerHeight);
+    }
+}
+
+
 // Hide switcher's parentNode if it has `data-hide`
 
 function addDisplayNone(e) {

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -53,9 +53,9 @@ $brandHeight: null;
     $brandHeight: $siteBrandFontSize * /* body line height */ 1.618;
 }
 
-:root
-{
-    @if ($headerLayoutFlex) {
+@if ($headerLayoutFlex) {
+    :root
+    {
         /* This is an approximate calculation, it won't cover all scenarios */
         --header-height: calc(
             max(
@@ -65,21 +65,21 @@ $brandHeight: null;
                 #{$brandHeight}
             ) + #{/* .header-wrapper top+bottom margin */ 2 * $fontSize}
         );
+    }
 
-        /* Work-around for anchors being hidden below the header */
-        #main
+    /* Work-around for anchors being hidden below the header */
+    #main
+    {
+        p, div, ul, ol, form, section, h1, h2, h3, h4, h5, h6
         {
-          p, div, ul, ol, form, section, h1, h2, h3, h4, h5, h6
-          {
             &[id]::before
             {
-              content: "";
-              display: block;
-              visibility: hidden;
-              height: var(--header-height);
-              margin: calc(-1 * var(--header-height)) 0 0;
+                content: "";
+                display: block;
+                visibility: hidden;
+                height: var(--header-height);
+                margin: calc(-1 * var(--header-height)) 0 0;
             }
-          }
         }
     }
 }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -67,15 +67,18 @@ $brandHeight: null;
         );
 
         /* Work-around for anchors being hidden below the header */
-        p, div, form, section, h1, h2, h3, h4, h5, h6
+        #main
         {
-          &[id]::before
+          p, div, ul, ol, form, section, h1, h2, h3, h4, h5, h6
           {
-            content: "";
-            display: block;
-            visibility: hidden;
-            height: var(--header-height);
-            margin: calc(-1 * var(--header-height)) 0 0;
+            &[id]::before
+            {
+              content: "";
+              display: block;
+              visibility: hidden;
+              height: var(--header-height);
+              margin: calc(-1 * var(--header-height)) 0 0;
+            }
           }
         }
     }

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -67,7 +67,7 @@ $brandHeight: null;
         );
 
         /* Work-around for anchors being hidden below the header */
-        p, div, ul, form, main, footer, nav, section, h1, h2, h3, h4, h5, h6
+        p, div, form, section, h1, h2, h3, h4, h5, h6
         {
           &[id]::before
           {

--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -33,12 +33,14 @@
     }
 }
 
+$brandHeight: null;
 @if ($siteBrandSVG) {
     .brand {
         width: $siteBrandSVGWidth;
         height: $siteBrandSVGHeight;
         fill: $siteBrandSVGFill;
     }
+    $brandHeight: $siteBrandSVGHeight;
 } @else {
     .brand {
         font-size: $siteBrandFontSize;
@@ -46,6 +48,35 @@
         text-decoration: none;
         &:hover {
             color: $siteBrandFontColor;
+        }
+    }
+    $brandHeight: $siteBrandFontSize * /* body line height */ 1.618;
+}
+
+:root
+{
+    @if ($headerLayoutFlex) {
+        /* This is an approximate calculation, it won't cover all scenarios */
+        --header-height: calc(
+            max(
+                /* menu */
+                #{$fontSize * /* .nav font size */ 0.8 * /* .menu line height */ 1.5},
+                /* brand */
+                #{$brandHeight}
+            ) + #{/* .header-wrapper top+bottom margin */ 2 * $fontSize}
+        );
+
+        /* Work-around for anchors being hidden below the header */
+        p, div, ul, form, main, footer, nav, section, h1, h2, h3, h4, h5, h6
+        {
+          &[id]::before
+          {
+            content: "";
+            display: block;
+            visibility: hidden;
+            height: var(--header-height);
+            margin: calc(-1 * var(--header-height)) 0 0;
+          }
         }
     }
 }


### PR DESCRIPTION
This implements the work-around described in #146. Since the header height has to be known, this will do an approximate calculation of the header height in CSS (already works well enough for me under most circumstances). The header will then be measured precisely by JavaScript if enabled.