### PR TITLE
fix: Remove unnecessary safeJS/safeURL calls

### DIFF
--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -32,7 +32,7 @@
             {{ if .Site.Params.shareOnTwitter }}
                 <div class="share-item twitter">
                     {{ $url := (printf `https://twitter.com/share?url=%s&text=%s&hashtags=%s&via=%s` .Permalink .Title ($hashtags.Get "tags" | default "") .Site.Params.siteTwitter) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "twitter" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "twitter" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "twitter" "class" "twitter-icon") -}}
                     </a>
                 </div>
@@ -41,7 +41,7 @@
             {{ if .Site.Params.shareOnFacebook }}
                 <div class="share-item facebook">
                     {{ $url := (printf `https://www.facebook.com/sharer/sharer.php?u=%s&hashtag=%s` .Permalink ($hashtags.Get "firsttag" | default "")) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "facebook" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "facebook" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "facebook" "class" "facebook-icon") -}}
                     </a>
                 </div>
@@ -50,7 +50,7 @@
             {{ if .Site.Params.shareOnLinkedIn }}
                 <div class="share-item linkedin">
                     {{ $url := (printf `https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s&summary=%s&source=%s` .Permalink .Title $description .Site.Title) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "linkedin" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "linkedin" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "linkedin" "class" "linkedin-icon") -}}
                     </a>
                 </div>
@@ -59,7 +59,7 @@
             {{ if .Site.Params.shareOnTelegram }}
                 <div class="share-item telegram">
                     {{ $url := (printf `https://t.me/share/url?url=%s&text=%s` .Permalink .Title) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "telegram" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "telegram" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "telegram" "class" "telegram-icon") -}}
                     </a>
                 </div>
@@ -68,7 +68,7 @@
             {{ if .Site.Params.shareOnWeibo }}
                 <div class="share-item weibo">
                     {{ $url := (printf `https://service.weibo.com/share/share.php?&url=%s&title=%s&pic=%s&searchPic=false` .Permalink .Title $images) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "weibo" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "weibo" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "weibo" "class" "weibo-icon") -}}
                     </a>
                 </div>
@@ -77,7 +77,7 @@
             {{ if .Site.Params.shareOnDouban }}
                 <div class="share-item douban">
                     {{ $url := (printf `https://www.douban.com/share/service?href=%s&name=%s&text=%s` .Permalink .Title $description) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "douban" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "douban" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "douban" "class" "douban-icon") -}}
                     </a>
                 </div>
@@ -86,7 +86,7 @@
             {{ if .Site.Params.shareOnQQ }}
                 <div class="share-item qq">
                     {{ $url := (printf `https://connect.qq.com/widget/shareqq/index.html?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink .Title $description $images .Site.Title) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qq" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qq" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "qq" "class" "qq-icon") -}}
                     </a>
                 </div>
@@ -95,7 +95,7 @@
             {{ if .Site.Params.shareOnQzone }}
                 <div class="share-item qzone">
                     {{ $url := (printf `https://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink .Title $description $images .Site.Title) }}
-                    <a href="{{ $url | safeURL }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qzone" }}" target="_blank" rel="noopener">
+                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qzone" }}" target="_blank" rel="noopener">
                         {{- partial "utils/icon.html" (dict "Deliver" . "name" "qzone" "class" "qzone-icon") -}}
                     </a>
                 </div>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -45,7 +45,7 @@
         {{ $url := urls.Parse .Site.BaseURL }}
         {{ $host := $url.Host }}
         <script>
-            if (window.location.host == "{{ $host | safeJS }}" && window.location.protocol != "https:") {
+            if (window.location.host == "{{ $host }}" && window.location.protocol != "https:") {
                 window.location.protocol = "https";
             }
         </script>


### PR DESCRIPTION
There is a remaining `safeJS` call in `partials/third-party/valine.html`. The documentation is lacking but judging by the default value this one is actually required - the value here really can be a JavaScript expression.