### PR TITLE
refactor: Rename $Deliver into $ for clarity

### DIFF
--- a/assets/js/lunr-search.js
+++ b/assets/js/lunr-search.js
@@ -71,7 +71,7 @@ window.addEventListener("DOMContentLoaded", event => {
 
     function initIndex() {
         let request = new XMLHttpRequest();
-        request.open("GET", "{{ partial "utils/relative-url.html" (dict "Deliver" . "filename" (((.Site.GetPage "").OutputFormats.Get "SearchIndex").RelPermalink | strings.TrimPrefix "/")) }}");
+        request.open("GET", "{{ partial "utils/relative-url.html" (dict "$" . "filename" (((.Site.GetPage "").OutputFormats.Get "SearchIndex").RelPermalink | strings.TrimPrefix "/")) }}");
         request.responseType = "json";
         request.addEventListener("load", function(event) {
             let documents = request.response;

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -70,7 +70,7 @@
                             {{ $.Scratch.Set "year" .Key }}
                         {{ end }}
                         {{ $year := $.Scratch.Get "year" }}
-                        <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ partial "utils/icon.html" (dict "Deliver" $ "name" $zodiacName "class" "chinese-zodiac") }}{{ end }}</h2>
+                        <h2 class="list-year">{{ $year }}{{ if $.Site.Params.chineseZodiac }}{{ partial "utils/icon.html" (dict "$" $ "name" $zodiacName "class" "chinese-zodiac") }}{{ end }}</h2>
                         {{ if $.Site.Params.groupByMonth }}
                             {{ range .Pages.GroupByDate "January" }}
                                 {{ $.Scratch.Delete "month" }}
@@ -82,10 +82,10 @@
                                 {{ end }}
                                 {{ $month := $.Scratch.Get "month" }}
                                 <h3 class="list-month">{{ $month }}</h3>
-                                {{ partial "utils/list-item.html" (dict "Deliver" .) }}
+                                {{ partial "utils/list-item.html" (dict "$" .) }}
                             {{ end }}
                         {{ else }}
-                            {{ partial "utils/list-item.html" (dict "Deliver" .) }}
+                            {{ partial "utils/list-item.html" (dict "$" .) }}
                         {{ end }}
                     {{ end }}
                 </div>

--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -5,11 +5,11 @@
         {{- end -}}
         {{- $entry := dict "uri" $page.RelPermalink "title" $page.Title "content" ($page.Plain | htmlUnescape) -}}
         {{- if $page.Params.subtitle -}}
-            {{- $subtitle := partial "utils/markdownify.html" (dict "Deliver" $page "raw" $page.Params.subtitle "isContent" false) -}}
+            {{- $subtitle := partial "utils/markdownify.html" (dict "$" $page "raw" $page.Params.subtitle "isContent" false) -}}
             {{- $entry = merge $entry (dict "subtitle" ($subtitle | plainify)) -}}
         {{- end -}}
         {{- if .Site.Params.displayPostDescription -}}
-            {{- $description := partial "utils/markdownify.html" (dict "Deliver" $page "raw" $page.Description "isContent" false) -}}
+            {{- $description := partial "utils/markdownify.html" (dict "$" $page "raw" $page.Description "isContent" false) -}}
             {{- $entry = merge $entry (dict "description" ($description | plainify)) -}}
         {{- end -}}
         {{- if .Site.Params.displayCategory -}}

--- a/layouts/index.sectionsatom.xml
+++ b/layouts/index.sectionsatom.xml
@@ -55,9 +55,9 @@
                 <rights>{{ . | plainify }}</rights>
             {{- end }}
             {{- $summary := .Description | default (partial "utils/summary.html" $page) -}}
-            <summary type="html">{{ partial "utils/make-links-absolute.html" (dict "Deliver" . "content" $summary) | html }}</summary>
+            <summary type="html">{{ partial "utils/make-links-absolute.html" (dict "$" . "content" $summary) | html }}</summary>
             {{ if $.Site.Params.includeContent }}
-                <content type="html">{{ partial "utils/make-links-absolute.html" (dict "Deliver" . "content" .Content) | html }}</content>
+                <content type="html">{{ partial "utils/make-links-absolute.html" (dict "$" . "content" .Content) | html }}</content>
             {{ end }}
             <!-- Sections -->
             {{ if eq $.Site.Params.categoryBy "sections" }}

--- a/layouts/index.sectionsrss.xml
+++ b/layouts/index.sectionsrss.xml
@@ -47,10 +47,10 @@
                     <copyright>{{ . | plainify }}</copyright>
                 {{- end }}
                 {{ if $.Site.Params.includeContent }}
-                    <description>{{ partial "utils/make-links-absolute.html" (dict "Deliver" . "content" .Content) | html }}</description>
+                    <description>{{ partial "utils/make-links-absolute.html" (dict "$" . "content" .Content) | html }}</description>
                 {{ else }}
                     {{- $summary := .Description | default (partial "utils/summary.html" $page) -}}
-                    <description>{{ partial "utils/make-links-absolute.html" (dict "Deliver" . "content" $summary) | html }}</description>
+                    <description>{{ partial "utils/make-links-absolute.html" (dict "$" . "content" $summary) | html }}</description>
                 {{ end }}
                 <!-- Sections -->
                 {{ if eq $.Site.Params.categoryBy "sections" }}

--- a/layouts/partials/components/back-to-top.html
+++ b/layouts/partials/components/back-to-top.html
@@ -1,5 +1,5 @@
 {{ if or (and .IsHome .Site.Params.displayBackToTopInHome) (and (not .IsHome) .Site.Params.enableBackToTop) }}
     <div id="back-to-top" class="back-to-top">
-        <a href="#">{{ partial "utils/icon.html" (dict "Deliver" . "name" .Site.Params.backToTopIcon) }}</a>
+        <a href="#">{{ partial "utils/icon.html" (dict "$" . "name" .Site.Params.backToTopIcon) }}</a>
     </div>
 {{ end }}

--- a/layouts/partials/components/dark-mode.html
+++ b/layouts/partials/components/dark-mode.html
@@ -2,8 +2,8 @@
     {{- $hide := or (and $.IsHome $.Site.Params.hideThemeToggleInHome) (and (not $.IsHome) $.Site.Params.hideThemeToggle) -}}
     {{- if not $hide -}}
         <a id="theme-switcher" href="#">
-            {{- partial "utils/icon.html" (dict "Deliver" $ "name" "sun" "class" "theme-icon-light") -}}
-            {{- partial "utils/icon.html" (dict "Deliver" $ "name" "moon" "class" "theme-icon-dark") -}}
+            {{- partial "utils/icon.html" (dict "$" $ "name" "sun" "class" "theme-icon-light") -}}
+            {{- partial "utils/icon.html" (dict "$" $ "name" "moon" "class" "theme-icon-dark") -}}
         </a>
     {{- end -}}
 {{- end -}}

--- a/layouts/partials/components/minimal-footer-about.html
+++ b/layouts/partials/components/minimal-footer-about.html
@@ -7,7 +7,7 @@
                         {{- $linkType := (string .Pre) -}}
                         {{- $iconName := (string .Post) -}}
                         {{- $icon := (index $.Site.Data.SVG $iconName) -}}
-                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
+                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "$" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{ end }}
                 </div>
             {{ end }}
@@ -17,7 +17,7 @@
                         {{- $linkType := (string .Pre) -}}
                         {{- $iconName := (string .Post) -}}
                         {{- $icon := (index $.Site.Data.SVG $iconName) -}}
-                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
+                        <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "$" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{ end }}
                 </div>
             {{ end }}

--- a/layouts/partials/components/post-copyright.html
+++ b/layouts/partials/components/post-copyright.html
@@ -1,4 +1,3 @@
-{{- $ := . -}}
 {{ if and .Site.Params.enablePostCopyright (.Params.displayCopyright | default .Site.Params.displayPostCopyright) }}
     {{ $author := partial "utils/author.html" . }}
     {{ with $author.name }}

--- a/layouts/partials/components/post-copyright.html
+++ b/layouts/partials/components/post-copyright.html
@@ -1,4 +1,4 @@
-{{- $Deliver := . -}}
+{{- $ := . -}}
 {{ if and .Site.Params.enablePostCopyright (.Params.displayCopyright | default .Site.Params.displayPostCopyright) }}
     {{ $author := partial "utils/author.html" . }}
     {{ with $author.name }}
@@ -23,7 +23,7 @@
             {{ end }}
             {{ with $author.copyright }}
                 {{- $raw := . -}}
-                <li class="copyright-item license"><span class="copyright-item-text">{{ i18n "copyrightLicense" }}</span>{{ i18n "colon" }}{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</li>
+                <li class="copyright-item license"><span class="copyright-item-text">{{ i18n "copyrightLicense" }}</span>{{ i18n "colon" }}{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</li>
             {{ end }}
         </ul>
     {{ end }}

--- a/layouts/partials/components/post-gitinfo.html
+++ b/layouts/partials/components/post-gitinfo.html
@@ -7,11 +7,11 @@
                         <div class="gitinfo-item commit">
                             {{- with .Site.Params.repoURL -}}
                                 <a href="{{ . }}/commit/{{ $.GitInfo.Hash }}" target="_blank" rel="noopener">
-                                    {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.gitIcon "class" "git-icon") -}}
+                                    {{- partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.gitIcon "class" "git-icon") -}}
                                     {{- $.GitInfo.AbbreviatedHash -}}
                                 </a>
                             {{- else -}}
-                                {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.gitIcon "class" "git-icon") -}}
+                                {{- partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.gitIcon "class" "git-icon") -}}
                                 {{- $.GitInfo.AbbreviatedHash -}}
                             {{- end -}}
                         </div>
@@ -19,7 +19,7 @@
                     {{ if .Site.Params.displayCommitMessage }}
                         {{ with .GitInfo.Subject }}
                             <div class="gitinfo-item commit-msg">
-                                {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.msgIcon "class" "msg-icon") -}}
+                                {{- partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.msgIcon "class" "msg-icon") -}}
                                 {{- . -}}
                             </div>
                         {{ end }}
@@ -32,7 +32,7 @@
                         {{ with .Site.Params.repoURL }}
                             <div class="gitinfo-item feedback">
                                 <a href="{{ . }}/issues" target="_blank" rel="noopener">
-                                    {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.feedbackIcon "class" "feedback-icon") -}}
+                                    {{- partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.feedbackIcon "class" "feedback-icon") -}}
                                     {{- $.Site.Params.feedbackText -}}
                                 </a>
                             </div>
@@ -43,7 +43,7 @@
                             {{ $contentDir := (cond $.Site.IsMultiLingual (printf `/%s/` $.Site.Params.contentDir) "/content/") }}
                             <div class="gitinfo-item edit">
                                 <a href="{{ . }}{{ $contentDir }}{{ $.Path }}" target="_blank" rel="noopener">
-                                    {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.editIcon "class" "edit-icon") -}}
+                                    {{- partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.editIcon "class" "edit-icon") -}}
                                     {{- $.Site.Params.editText -}}
                                 </a>
                             </div>

--- a/layouts/partials/components/post-meta.html
+++ b/layouts/partials/components/post-meta.html
@@ -1,45 +1,45 @@
-{{ $Deliver := .Deliver }}
+{{ $ := index . "$" }}
 {{ $isHome := .isHome }}
 <div class="post-meta">
-    {{ if and $Deliver.Site.Params.displayPublishedDate (not $Deliver.PublishDate.IsZero) }}
-        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.publishedDateIcon "class" "post-meta-icon") }}
-        <time datetime="{{ $Deliver.PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item published">{{ $icon }}&nbsp;{{ $Deliver.PublishDate.Format $Deliver.Site.Params.postMetaDateFormat }}</time>
+    {{ if and $.Site.Params.displayPublishedDate (not $.PublishDate.IsZero) }}
+        {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.publishedDateIcon "class" "post-meta-icon") }}
+        <time datetime="{{ $.PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item published">{{ $icon }}&nbsp;{{ $.PublishDate.Format $.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
-    {{ if and $Deliver.Site.Params.displayModifiedDate (not $Deliver.Lastmod.IsZero) }}
-        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.modifiedDateIcon "class" "post-meta-icon") }}
-        <time datetime="{{ $Deliver.Lastmod.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item modified">{{ $icon }}&nbsp;{{ $Deliver.Lastmod.Format $Deliver.Site.Params.postMetaDateFormat }}</time>
+    {{ if and $.Site.Params.displayModifiedDate (not $.Lastmod.IsZero) }}
+        {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.modifiedDateIcon "class" "post-meta-icon") }}
+        <time datetime="{{ $.Lastmod.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item modified">{{ $icon }}&nbsp;{{ $.Lastmod.Format $.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
-    {{ if and $Deliver.Site.Params.displayExpiredDate (not $Deliver.ExpiryDate.IsZero) }}
-        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.expiredDateIcon "class" "post-meta-icon") }}
-        <time datetime="{{ $Deliver.ExpiryDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item expired">{{ $icon }}&nbsp;{{ $Deliver.ExpiryDate.Format $Deliver.Site.Params.postMetaDateFormat }}</time>
+    {{ if and $.Site.Params.displayExpiredDate (not $.ExpiryDate.IsZero) }}
+        {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.expiredDateIcon "class" "post-meta-icon") }}
+        <time datetime="{{ $.ExpiryDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item expired">{{ $icon }}&nbsp;{{ $.ExpiryDate.Format $.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
-    {{ if $Deliver.Site.Params.displayCategory }}
-        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.categoryIcon "class" "post-meta-icon") }}
-        {{ if and (eq $Deliver.Site.Params.categoryBy "sections") (in $Deliver.Site.Params.mainSections $Deliver.Section) }}
-            {{ $sections := split (strings.TrimSuffix "/" ($Deliver.File.Dir | default $Deliver.Section)) "/" }}
+    {{ if $.Site.Params.displayCategory }}
+        {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.categoryIcon "class" "post-meta-icon") }}
+        {{ if and (eq $.Site.Params.categoryBy "sections") (in $.Site.Params.mainSections $.Section) }}
+            {{ $sections := split (strings.TrimSuffix "/" ($.File.Dir | default $.Section)) "/" }}
             {{ with $sections }}
-                {{ $Deliver.Scratch.Delete "sectionsDirMeta" }}
-                {{ $Deliver.Scratch.Delete "sectionsMeta" }}
-                {{ $Deliver.Scratch.Set "index" 0 }}
+                {{ $.Scratch.Delete "sectionsDirMeta" }}
+                {{ $.Scratch.Delete "sectionsMeta" }}
+                {{ $.Scratch.Set "index" 0 }}
                 {{ range $sections }}
                     {{ $section := . }}
-                    {{ $Deliver.Scratch.Add "sectionsDirMeta" (printf `/%s` $section) }}
-                    {{ with $Deliver.Site.GetPage ($Deliver.Scratch.Get "sectionsDirMeta") }}
+                    {{ $.Scratch.Add "sectionsDirMeta" (printf `/%s` $section) }}
+                    {{ with $.Site.GetPage ($.Scratch.Get "sectionsDirMeta") }}
                         {{ if (eq .Kind "section") }}
-                            {{ $Deliver.Scratch.SetInMap "sectionsMeta" (printf `%s/%s` (string ($Deliver.Scratch.Get "index")) .RelPermalink) (.LinkTitle | default $section) }}
-                            {{ $Deliver.Scratch.Set "index" (add ($Deliver.Scratch.Get "index") 1) }}
+                            {{ $.Scratch.SetInMap "sectionsMeta" (printf `%s/%s` (string ($.Scratch.Get "index")) .RelPermalink) (.LinkTitle | default $section) }}
+                            {{ $.Scratch.Set "index" (add ($.Scratch.Get "index") 1) }}
                         {{ end }}
                     {{ end }}
                 {{ end }}
             {{ end }}
-            {{ $sections := $Deliver.Scratch.Get "sectionsMeta" }}
+            {{ $sections := $.Scratch.Get "sectionsMeta" }}
             {{ with $sections }}
                 <span class="post-meta-item category">
                     {{- $icon -}}&nbsp;
                     {{- range $link, $title := $sections -}}
                         {{- $index := $link | replaceRE `(\d+)/.+` `$1` | int -}}
                         {{- if ne $index 0 }}
-                            {{- $Deliver.Site.Params.categoryDelimiter | default "/" -}}
+                            {{- $.Site.Params.categoryDelimiter | default "/" -}}
                         {{- end -}}
                         <a href="{{- $link | replaceRE `\d+/(.+)` `$1` -}}" class="category-link">
                             {{- $title -}}
@@ -48,17 +48,17 @@
                 </span>
             {{ end }}
         {{ end }}
-        {{ if eq $Deliver.Site.Params.categoryBy "categories" }}
-            {{ with $Deliver.Params.categories }}
+        {{ if eq $.Site.Params.categoryBy "categories" }}
+            {{ with $.Params.categories }}
                 <span class="post-meta-item category">
                     {{- $icon -}}&nbsp;
                     {{- range $index, $category := . -}}
                         {{- if ne $index 0 -}}
-                            {{- $Deliver.Site.Params.categoryDelimiter | default "/" -}}
+                            {{- $.Site.Params.categoryDelimiter | default "/" -}}
                         {{- end -}}
                         <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
                         {{- $path := (urls.Parse ($category | urlize)).Path -}}
-                        {{- with $Deliver.Site.GetPage (printf `/categories/%s` $path) -}}
+                        {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
                             <a href="{{- .RelPermalink -}}" class="category-link">
                                 {{- .LinkTitle | default $path -}}
                             </a>
@@ -68,19 +68,19 @@
             {{ end }}
         {{ end }}
     {{ end }}
-    {{ if $Deliver.Site.Params.displayWordCount }}
-        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.wordCountIcon "class" "post-meta-icon") }}
-        <span class="post-meta-item wordcount">{{ $icon }}&nbsp;{{ $Deliver.WordCount }}</span>
+    {{ if $.Site.Params.displayWordCount }}
+        {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.wordCountIcon "class" "post-meta-icon") }}
+        <span class="post-meta-item wordcount">{{ $icon }}&nbsp;{{ $.WordCount }}</span>
     {{ end }}
-    {{ if $Deliver.Site.Params.displayReadingTime }}
-        {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.readingTimeIcon "class" "post-meta-icon") }}
-        <span class="post-meta-item reading-time">{{ $icon }}&nbsp;{{ $Deliver.ReadingTime }}&nbsp;{{ i18n "minute" $Deliver.ReadingTime }}</span>
+    {{ if $.Site.Params.displayReadingTime }}
+        {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.readingTimeIcon "class" "post-meta-icon") }}
+        <span class="post-meta-item reading-time">{{ $icon }}&nbsp;{{ $.ReadingTime }}&nbsp;{{ i18n "minute" $.ReadingTime }}</span>
     {{ end }}
-    {{ if and $Deliver.Site.Params.displayBusuanziPagePV (eq hugo.Environment "production") }}
+    {{ if and $.Site.Params.displayBusuanziPagePV (eq hugo.Environment "production") }}
         {{ if not $isHome }}
-            {{ $icon := partial "utils/icon.html" (dict "Deliver" $Deliver "name" $Deliver.Site.Params.busuanziPagePVIcon "class" "post-meta-icon") }}
+            {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.busuanziPagePVIcon "class" "post-meta-icon") }}
             <span class="post-meta-item busuanzi-page-pv" id="busuanzi_container_page_pv">{{ $icon }}&nbsp;<span id="busuanzi_value_page_pv"></span></span>
         {{ end }}
     {{ end }}
-    {{ partial "custom/post-meta.html" $Deliver }}
+    {{ partial "custom/post-meta.html" $ }}
 </div>

--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -33,7 +33,7 @@
                 <div class="share-item twitter">
                     {{ $url := (printf `https://twitter.com/share?url=%s&text=%s&hashtags=%s&via=%s` .Permalink .Title ($hashtags.Get "tags" | default "") .Site.Params.siteTwitter) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "twitter" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "twitter" "class" "twitter-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "twitter" "class" "twitter-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -42,7 +42,7 @@
                 <div class="share-item facebook">
                     {{ $url := (printf `https://www.facebook.com/sharer/sharer.php?u=%s&hashtag=%s` .Permalink ($hashtags.Get "firsttag" | default "")) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "facebook" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "facebook" "class" "facebook-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "facebook" "class" "facebook-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -51,7 +51,7 @@
                 <div class="share-item linkedin">
                     {{ $url := (printf `https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s&summary=%s&source=%s` .Permalink .Title $description .Site.Title) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "linkedin" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "linkedin" "class" "linkedin-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "linkedin" "class" "linkedin-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -60,7 +60,7 @@
                 <div class="share-item telegram">
                     {{ $url := (printf `https://t.me/share/url?url=%s&text=%s` .Permalink .Title) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "telegram" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "telegram" "class" "telegram-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "telegram" "class" "telegram-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -69,7 +69,7 @@
                 <div class="share-item weibo">
                     {{ $url := (printf `https://service.weibo.com/share/share.php?&url=%s&title=%s&pic=%s&searchPic=false` .Permalink .Title $images) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "weibo" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "weibo" "class" "weibo-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "weibo" "class" "weibo-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -78,7 +78,7 @@
                 <div class="share-item douban">
                     {{ $url := (printf `https://www.douban.com/share/service?href=%s&name=%s&text=%s` .Permalink .Title $description) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "douban" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "douban" "class" "douban-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "douban" "class" "douban-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -87,7 +87,7 @@
                 <div class="share-item qq">
                     {{ $url := (printf `https://connect.qq.com/widget/shareqq/index.html?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink .Title $description $images .Site.Title) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qq" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "qq" "class" "qq-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "qq" "class" "qq-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -96,7 +96,7 @@
                 <div class="share-item qzone">
                     {{ $url := (printf `https://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink .Title $description $images .Site.Title) }}
                     <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qzone" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "qzone" "class" "qzone-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "qzone" "class" "qzone-icon") -}}
                     </a>
                 </div>
             {{ end }}
@@ -104,7 +104,7 @@
             {{ if .Site.Params.shareViaQRCode }}
                 <div class="share-item qrcode">
                     <div class="qrcode-container" title="{{ i18n "shareViaTitle" }}{{ i18n "qrcode" }}">
-                        {{- partial "utils/icon.html" (dict "Deliver" . "name" "qrcode" "class" "qrcode-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" . "name" "qrcode" "class" "qrcode-icon") -}}
                         <div id="qrcode-img"></div>
                     </div>
                     {{ partial "third-party/qrcode-generator.html" . }}

--- a/layouts/partials/components/post-tags.html
+++ b/layouts/partials/components/post-tags.html
@@ -6,7 +6,7 @@
                 <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
                 {{ $path := (urls.Parse ($tag | urlize)).Path }}
                 {{ with $.Site.GetPage (printf `/tags/%s` $path) }}
-                    {{ $icon := partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.postTagsIcon "class" "tag-icon") }}
+                    {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.postTagsIcon "class" "tag-icon") }}
                     <a href="{{ .RelPermalink }}" rel="tag" class="post-tags-link">{{ $icon  }}{{ .LinkTitle | default $path }}</a>
                 {{ end }}
             {{ end }}

--- a/layouts/partials/components/related-posts.html
+++ b/layouts/partials/components/related-posts.html
@@ -2,7 +2,7 @@
     {{ $related := .Site.RegularPages.Related . | first (.Site.Params.relatedPostsNumber | default 5) }}
     {{ with $related }}
         <div class="related-posts">
-            <h2 class="related-title">{{ i18n "relatedPosts" }}{{ partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.relatedPostsIcon "class" "related-icon") }}</h2>
+            <h2 class="related-title">{{ i18n "relatedPosts" }}{{ partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.relatedPostsIcon "class" "related-icon") }}</h2>
             <ul class="related-list">
                 {{ range . }}
                     <li class="related-item">

--- a/layouts/partials/components/search.html
+++ b/layouts/partials/components/search.html
@@ -1,8 +1,8 @@
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 {{- $iconName := .iconName | default "search" -}}
 <form id="search" class="search" role="search">
     <label for="search-input">
-        {{- partial "utils/icon.html" (dict "Deliver" $Deliver "name" $iconName "class" "search-icon") -}}
+        {{- partial "utils/icon.html" (dict "$" $ "name" $iconName "class" "search-icon") -}}
     </label>
     <input type="search" id="search-input" class="search-input">
 </form>

--- a/layouts/partials/components/socials.html
+++ b/layouts/partials/components/socials.html
@@ -4,7 +4,7 @@
             {{- range sort .socials "weight" -}}
                 <li class="socials-item">
                     <a href="{{ .url }}" target="_blank" rel="external noopener" title="{{ .title }}">
-                        {{- partial "utils/icon.html" (dict "Deliver" $ "name" .icon "class" "social-icon") -}}
+                        {{- partial "utils/icon.html" (dict "$" $ "name" .icon "class" "social-icon") -}}
                     </a>
                 </li>
             {{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,3 @@
-{{- $ := . -}}
 {{ if or (and .IsHome .Site.Params.displayFooterInHome) (and (not .IsHome) .Site.Params.enableFooter) }}
     <footer id="footer" class="footer">
         <div class="footer-inner">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,4 @@
-{{- $Deliver := . -}}
+{{- $ := . -}}
 {{ if or (and .IsHome .Site.Params.displayFooterInHome) (and (not .IsHome) .Site.Params.enableFooter) }}
     <footer id="footer" class="footer">
         <div class="footer-inner">
@@ -13,7 +13,7 @@
               {{- now.Format "2006" -}}
 
               {{- with .Site.Params.iconBetweenYearAndAuthor -}}
-                  &nbsp;{{- partial "utils/icon.html" (dict "Deliver" $Deliver "name" . "class" "footer-icon") -}}&nbsp;
+                  &nbsp;{{- partial "utils/icon.html" (dict "$" $ "name" . "class" "footer-icon") -}}&nbsp;
               {{- else -}}
                   &nbsp;
               {{- end -}}
@@ -23,17 +23,17 @@
 
             {{- if .Site.Params.displayPoweredBy }}
                 {{- $raw := `Powered by [Hugo](https://github.com/gohugoio/hugo) | Theme is [MemE](https://github.com/reuixiy/hugo-theme-meme)` -}}
-                <div class="powered-by">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
+                <div class="powered-by">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
             {{- end }}
 
             {{- if .Site.Params.displaySiteCopyright }}
                 {{- $raw := .Site.Copyright -}}
-                <div class="site-copyright">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
+                <div class="site-copyright">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
             {{- end }}
 
             {{- with .Site.Params.customFooter }}
                 {{- $raw := . -}}
-                <div class="custom-footer">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
+                <div class="custom-footer">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
             {{- end }}
 
             {{- if and .Site.Params.displayBusuanziSiteUVAndPV (eq hugo.Environment "production") }}
@@ -45,7 +45,7 @@
                         {{- end -}}
 
                         {{- with .Site.Params.busuanziSiteUVIcon -}}
-                            {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.busuanziSiteUVIcon "class" "busuanzi-site-uv") -}}
+                            {{- partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.busuanziSiteUVIcon "class" "busuanzi-site-uv") -}}
                             &nbsp;
                         {{- end -}}
 
@@ -62,7 +62,7 @@
                         {{- end -}}
 
                         {{- with .Site.Params.busuanziSitePVIcon -}}
-                            {{- partial "utils/icon.html" (dict "Deliver" $ "name" $.Site.Params.busuanziSitePVIcon "class" "busuanzi-site-pv") -}}
+                            {{- partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.busuanziSitePVIcon "class" "busuanzi-site-pv") -}}
                             &nbsp;
                         {{- end -}}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,9 +44,9 @@
     {{- $safariMaskIcon := "icons/safari-pinned-tab.svg" -}}
     {{- $safariMaskColor := .Site.Params.safariMaskColor -}}
     {{- $appleTouchIcon := "icons/apple-touch-icon.png" -}}
-    {{- $msApplicationStartURL := partial "utils/relative-url.html" (dict "Deliver" . "filename" "") -}}
+    {{- $msApplicationStartURL := partial "utils/relative-url.html" (dict "$" . "filename" "") -}}
     {{- $msApplicationTileColor := .Site.Params.msApplicationTileColor -}}
-    {{- $msApplicationTileImage := partial "utils/relative-url.html" (dict "Deliver" . "filename" "icons/mstile-150x150.png") -}}
+    {{- $msApplicationTileImage := partial "utils/relative-url.html" (dict "$" . "filename" "icons/mstile-150x150.png") -}}
     {{- $manifest := "manifest.json" -}}
     <link rel="shortcut icon" href="{{ $favicon | relURL }}" type="image/x-icon" />
     <link rel="mask-icon" href="{{ $safariMaskIcon | relURL }}" color="{{ $safariMaskColor }}" />
@@ -71,19 +71,19 @@
 
     <!-- SEO -->
     <link rel="canonical" href="{{ .Permalink }}" />
-    {{- $Deliver := . -}}
+    {{- $ := . -}}
     <!-- JSON-LD -->
     {{- with .Site.Params.jsonLD -}}
-        {{ partial "utils/json-ld.html" (dict "Deliver" $Deliver "description" $description) }}
+        {{ partial "utils/json-ld.html" (dict "$" $ "description" $description) }}
     {{- end }}
 
     <!-- Twitter Cards -->
     {{- with .Site.Params.twitterCards -}}
-        {{ partial "utils/twitter-cards.html" (dict "Deliver" $Deliver) }}
+        {{ partial "utils/twitter-cards.html" (dict "$" $) }}
     {{- end }}
     <!-- Open Graph -->
     {{- with .Site.Params.openGraph -}}
-        {{ partial "utils/open-graph.html" (dict "Deliver" $Deliver "description" $description) }}
+        {{ partial "utils/open-graph.html" (dict "$" $ "description" $description) }}
     {{- end }}
 
     {{- with .Site.Params.googleSiteVerification }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -71,7 +71,6 @@
 
     <!-- SEO -->
     <link rel="canonical" href="{{ .Permalink }}" />
-    {{- $ := . -}}
     <!-- JSON-LD -->
     {{- with .Site.Params.jsonLD -}}
         {{ partial "utils/json-ld.html" (dict "$" $ "description" $description) }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -18,7 +18,7 @@
 {{ define "site-brand" }}
     <div class="site-brand">
         {{ if .Site.Params.siteBrandSVG }}
-            <a href="{{ print `/` | relLangURL }}">{{ partial "utils/icon.html" (dict "Deliver" . "name" "brand") }}</a>
+            <a href="{{ print `/` | relLangURL }}">{{ partial "utils/icon.html" (dict "$" . "name" "brand") }}</a>
         {{ else }}
             <a href="{{ print `/` | relLangURL }}" class="brand">{{ .Site.Title }}</a>
         {{ end }}

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -32,7 +32,7 @@
                 {{ if and $.Site.Params.enableLunrSearch (eq $.Site.Params.headerLayout "flex") }}
                     {{- $iconName := (string .Post) -}}
                     <li class="menu-item search-item">
-                        {{ partial "components/search.html" (dict "Deliver" $ctx "iconName" $iconName) }}
+                        {{ partial "components/search.html" (dict "$" $ctx "iconName" $iconName) }}
                     </li>
                 {{ end }}
             {{ else }}
@@ -40,7 +40,7 @@
                     {{- $linkType := (string .Pre) -}}
                     <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>
                         {{- $iconName := (string .Post) -}}
-                        {{- partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) -}}
+                        {{- partial "utils/icon.html" (dict "$" $ "name" $iconName "class" .Identifier) -}}
                         {{- with .Name -}}
                             <span class="menu-item-name">{{ . }}</span>
                         {{- end -}}

--- a/layouts/partials/pages/home-footage.html
+++ b/layouts/partials/pages/home-footage.html
@@ -26,7 +26,7 @@
                 {{ range $index, $value := . }}
                     {{- $linkType := (string .Pre) -}}
                     {{- $iconName := (string .Post) -}}
-                    <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
+                    <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "$" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{- if lt $index $length -}}
                         {{- $.Site.Params.homeLinksDelimiter -}}
                     {{- end -}}

--- a/layouts/partials/pages/home-poetry.html
+++ b/layouts/partials/pages/home-poetry.html
@@ -1,4 +1,3 @@
-{{- $ := . -}}
 <main class="home">
     <div class="poetry">
         {{ range .Site.Params.homePoetry }}

--- a/layouts/partials/pages/home-poetry.html
+++ b/layouts/partials/pages/home-poetry.html
@@ -1,8 +1,8 @@
-{{- $Deliver := . -}}
+{{- $ := . -}}
 <main class="home">
     <div class="poetry">
         {{ range .Site.Params.homePoetry }}
-            <p>{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" . "isContent" false) }}</p>
+            <p>{{ partial "utils/markdownify.html" (dict "$" $ "raw" . "isContent" false) }}</p>
         {{ end }}
     </div>
     {{ with .Site.Menus.home }}
@@ -10,7 +10,7 @@
             {{ range . }}
                 {{- $linkType := (string .Pre) -}}
                 {{- $iconName := (string .Post) -}}
-                <a href="{{ .URL }}" class="links-item"{{ if eq $linkType "external" }} target="_blank" rel="noopener"{{ end }}>{{ partial "utils/icon.html" (dict "Deliver" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
+                <a href="{{ .URL }}" class="links-item"{{ if eq $linkType "external" }} target="_blank" rel="noopener"{{ end }}>{{ partial "utils/icon.html" (dict "$" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
             {{ end }}
         </div>
     {{ end }}

--- a/layouts/partials/pages/home-posts.html
+++ b/layouts/partials/pages/home-posts.html
@@ -7,7 +7,7 @@
                     <a href="{{ .RelPermalink }}" class="summary-title-link">{{ .LinkTitle }}</a>
                 </h2>
                 {{ if $.Site.Params.enablePostMetaInHome }}
-                    {{ partial "components/post-meta.html" (dict "Deliver" . "isHome" true) }}
+                    {{ partial "components/post-meta.html" (dict "$" . "isHome" true) }}
                 {{ end }}
                 <summary class="summary">
                     {{ partial "utils/summary.html" . }}

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -1,4 +1,4 @@
-{{- $Deliver := . -}}
+{{- $ := . -}}
 <main class="main single" id="main">
     <div class="main-inner">
 
@@ -16,18 +16,18 @@
 
             {{ with .Params.subtitle }}
                 {{- $raw := . -}}
-                <div class="post-subtitle">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
+                <div class="post-subtitle">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
             {{ end }}
 
             {{ if .Site.Params.displayPostDescription }}
                 {{ with .Params.description }}
                     {{- $raw := . -}}
-                    <div class="post-description">{{ partial "utils/markdownify.html" (dict "Deliver" $Deliver "raw" $raw "isContent" false) }}</div>
+                    <div class="post-description">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
                 {{ end }}
             {{ end }}
 
             {{ if .Params.meta | default .Site.Params.enablePostMeta }}
-                {{ partial "components/post-meta.html" (dict "Deliver" . "isHome" false) }}
+                {{ partial "components/post-meta.html" (dict "$" . "isHome" false) }}
             {{ end }}
 
             {{ $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -1,4 +1,3 @@
-{{- $ := . -}}
 <main class="main single" id="main">
     <div class="main-inner">
 

--- a/layouts/partials/pages/taxonomy.html
+++ b/layouts/partials/pages/taxonomy.html
@@ -16,7 +16,7 @@
                         <span class="term-count">{{ printf "(%d)" .Count }}</span>
                     {{ end }}
                 </h2>
-                {{ partial "utils/list-item.html" (dict "Deliver" . "linkTarget" $page) }}
+                {{ partial "utils/list-item.html" (dict "$" . "linkTarget" $page) }}
             {{ end }}
         </div>
     </div>

--- a/layouts/partials/third-party/service-worker.html
+++ b/layouts/partials/third-party/service-worker.html
@@ -1,5 +1,5 @@
 {{ if and .Site.Params.enableServiceWorker (eq hugo.Environment "production") }}
-    {{- $url := partial "utils/relative-url.html" (dict "Deliver" . "filename" "sw.js") -}}
+    {{- $url := partial "utils/relative-url.html" (dict "$" . "filename" "sw.js") -}}
 
     <div class="app-refresh" id="app-refresh">
         <div class="app-refresh-wrap" onclick="location.reload()">

--- a/layouts/partials/third-party/utterances.html
+++ b/layouts/partials/third-party/utterances.html
@@ -20,7 +20,7 @@
             script.crossOrigin = 'anonymous';
             script.setAttribute('repo', '{{ .Site.Params.utterancesRepo }}');
             script.setAttribute('issue-term', '{{ .Site.Params.utterancesIssueTerm }}');
-            {{ template "theme" (dict "Deliver" . "theme" $theme) }}
+            {{ template "theme" (dict "$" . "theme" $theme) }}
             {{ with .Site.Params.utterancesLabel }}
                 script.setAttribute('label', '{{ . }}');
             {{ end }}
@@ -29,20 +29,20 @@
     }
 </script>
 {{- define "theme" -}}
-    {{- $Deliver := .Deliver -}}
+    {{- $ := index . "$" -}}
     {{- $theme := .theme -}}
-    {{- if $Deliver.Site.Params.enableDarkMode -}}
+    {{- if $.Site.Params.enableDarkMode -}}
         const userPrefers = localStorage.getItem('theme');
         const darkModeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
         const lightModeMediaQuery = window.matchMedia('(prefers-color-scheme: light)');
         if (userPrefers === "dark") {
-            script.setAttribute('theme', '{{ $Deliver.Site.Params.utterancesThemeDark }}');
+            script.setAttribute('theme', '{{ $.Site.Params.utterancesThemeDark }}');
         } else if (userPrefers === "light") {
-            script.setAttribute('theme', '{{ $Deliver.Site.Params.utterancesTheme }}');
+            script.setAttribute('theme', '{{ $.Site.Params.utterancesTheme }}');
         } else if (darkModeMediaQuery.matches) {
-            script.setAttribute('theme', '{{ $Deliver.Site.Params.utterancesThemeDark }}');
+            script.setAttribute('theme', '{{ $.Site.Params.utterancesThemeDark }}');
         } else if (lightModeMediaQuery.matches) {
-            script.setAttribute('theme', '{{ $Deliver.Site.Params.utterancesTheme }}');
+            script.setAttribute('theme', '{{ $.Site.Params.utterancesTheme }}');
         }
     {{- else -}}
         script.setAttribute('theme', '{{ $theme }}');

--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -1,4 +1,3 @@
-{{- $ := . -}}
 {{- $Content := partial "utils/markdownify.html" (dict "$" . "raw" .Content "isContent" true) -}}
 
 <!-- Link Headings to TOC -->

--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -1,5 +1,5 @@
-{{- $Deliver := . -}}
-{{- $Content := partial "utils/markdownify.html" (dict "Deliver" . "raw" .Content "isContent" true) -}}
+{{- $ := . -}}
+{{- $Content := partial "utils/markdownify.html" (dict "$" . "raw" .Content "isContent" true) -}}
 
 <!-- Link Headings to TOC -->
 {{- $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
@@ -91,7 +91,7 @@
 
 <!-- Replace `footnoteReturnLinkContents` with icon -->
 {{- with .Site.Params.footnoteReturnLinkIcon -}}
-    {{- $icon := (partial "utils/icon.html" (dict "Deliver" $ "name" . "class" "footnote-icon")) -}}
+    {{- $icon := (partial "utils/icon.html" (dict "$" $ "name" . "class" "footnote-icon")) -}}
     {{- $replacement := (printf `${1}%s$3` $icon) -}}
 
     {{- $regexPatternfootnoteReturnLinkIcon := `(href="#fnref[^>]+>)([^<]+)(.+)` -}}
@@ -187,7 +187,7 @@
 {{- end -}}
 
 <!-- Custom -->
-{{- $Content = partial "custom/content.html" (dict "Deliver" $Deliver "Content" $Content) | default $Content -}}
+{{- $Content = partial "custom/content.html" (dict "$" $ "Content" $Content) | default $Content -}}
 
 <!-- Final Content -->
 {{- $Content | safeHTML -}}

--- a/layouts/partials/utils/icon.html
+++ b/layouts/partials/utils/icon.html
@@ -1,6 +1,6 @@
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 {{- $name := .name -}}
 {{- $class := .class | default $name -}}
-{{- $icon := index $Deliver.Site.Data.SVG $name -}}
+{{- $icon := index $.Site.Data.SVG $name -}}
 {{- $class := printf "icon %s" $class -}}
 {{- return (replace $icon "icon" $class | safeHTML) -}}

--- a/layouts/partials/utils/json-ld.html
+++ b/layouts/partials/utils/json-ld.html
@@ -1,19 +1,19 @@
 <!-- https://schema.org/ -->
 <!-- https://json-ld.org/ -->
 <!-- https://search.google.com/structured-data/testing-tool -->
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 {{- $description := .description -}}
 {{- $baseURLWithLangFix := print `/` | absLangURL -}}
 <!-- Title -->
-{{- $rawTitle := (partial "utils/title.html" $Deliver).rawTitle -}}
+{{- $rawTitle := (partial "utils/title.html" $).rawTitle -}}
 <!-- Date -->
-{{- $dates := partial "utils/date.html" $Deliver -}}
+{{- $dates := partial "utils/date.html" $ -}}
 <!-- Author -->
-{{- $author := partial "utils/author.html" $Deliver -}}
+{{- $author := partial "utils/author.html" $ -}}
 <!-- Images -->
-{{- $images := partial "utils/images.html" $Deliver -}}
+{{- $images := partial "utils/images.html" $ -}}
 
-{{- if $Deliver.IsHome -}}
+{{- if $.IsHome -}}
 <script type="application/ld+json">
     {
         "@context": "https://schema.org",
@@ -22,7 +22,7 @@
         "dateModified": {{ $dates.modDate }},
         "url": {{ $baseURLWithLangFix }},
         "description": {{ $description }},
-        {{ with $Deliver.Site.Params.siteLogo -}}
+        {{ with $.Site.Params.siteLogo -}}
         "image": {{ . | absURL }},
         {{ end -}}
         {{ with $author -}}
@@ -51,23 +51,23 @@
         "name": {{ $rawTitle }}
     }
 </script>
-{{- else if and $Deliver.IsPage (in $Deliver.Site.Params.mainSections $Deliver.Section) -}}
+{{- else if and $.IsPage (in $.Site.Params.mainSections $.Section) -}}
 <script type="application/ld+json">
     {
         "@context": "https://schema.org",
         "@type": "BlogPosting",
         "datePublished": {{ $dates.pubDate }},
         "dateModified": {{ $dates.modDate }},
-        "url": {{ $Deliver.Permalink }},
+        "url": {{ $.Permalink }},
         "headline": {{ $rawTitle }},
         "description": {{ $description }},
-        "inLanguage" : "{{ $Deliver.Site.LanguageCode }}",
-        "articleSection": {{ $Deliver.Section }},
-        "wordCount": {{ $Deliver.WordCount }},
+        "inLanguage" : "{{ $.Site.LanguageCode }}",
+        "articleSection": {{ $.Section }},
+        "wordCount": {{ $.WordCount }},
         {{ with $images -}}
         "image": {{ . }},
         {{ else -}}
-        {{ with $Deliver.Site.Params.siteLogo -}}
+        {{ with $.Site.Params.siteLogo -}}
         "image": {{ . | absURL }},
         {{ end -}}
         {{ end -}}
@@ -96,8 +96,8 @@
         {{ end -}}
         "publisher": {
             "@type": "Organization",
-            "name": {{ $Deliver.Site.Title }},
-            {{ with $Deliver.Site.Params.siteLogo -}}
+            "name": {{ $.Site.Title }},
+            {{ with $.Site.Params.siteLogo -}}
             "logo": {
                 "@type": "ImageObject",
                 "url": {{ . | absURL }}
@@ -118,13 +118,13 @@
         "@type": "WebPage",
         "datePublished": {{ $dates.pubDate }},
         "dateModified": {{ $dates.modDate }},
-        "url": {{ $Deliver.Permalink }},
+        "url": {{ $.Permalink }},
         "name": {{ $rawTitle }},
         "description": {{ $description }},
         {{ with $images -}}
         "image": {{ . }},
         {{ else -}}
-        {{ with $Deliver.Site.Params.siteLogo -}}
+        {{ with $.Site.Params.siteLogo -}}
         "image": {{ . | absURL }},
         {{ end -}}
         {{ end -}}
@@ -133,8 +133,8 @@
         {{ end -}}
         "publisher": {
             "@type": "Organization",
-            "name": {{ $Deliver.Site.Title }},
-            {{ with $Deliver.Site.Params.siteLogo -}}
+            "name": {{ $.Site.Title }},
+            {{ with $.Site.Params.siteLogo -}}
             "logo": {
                 "@type": "ImageObject",
                 "url": {{ . | absURL }}

--- a/layouts/partials/utils/list-item.html
+++ b/layouts/partials/utils/list-item.html
@@ -1,5 +1,6 @@
 {{- $linkTarget := .linkTarget -}}
-{{- $pages := .Deliver.Pages -}}
+{{- $ := index . "$" -}}
+{{- $pages := $.Pages -}}
 {{- $limit := -1 -}}
 {{- with $linkTarget -}}
     {{- if isset (index $pages 0).Site.Params "limitentrieslimit" -}}
@@ -17,7 +18,7 @@
                 <time datetime="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="list-item-time">{{ .PublishDate.Format .Site.Params.listDateFormat }}</time>
             </li>
         {{ end }}
-        {{ if and (gt $limit 0) (gt (len $.Deliver.Pages) $limit) }}
+        {{ if and (gt $limit 0) (gt (len $.Pages) $limit) }}
             {{ with $linkTarget }}
                 <li class="list-read-more">
                     <a href="{{ $linkTarget.RelPermalink }}">{{ i18n "readMore" }} »</a>

--- a/layouts/partials/utils/make-links-absolute.html
+++ b/layouts/partials/utils/make-links-absolute.html
@@ -1,6 +1,6 @@
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 {{- $content := .content -}}
-{{- $baseURL := ($Deliver.Site.BaseURL | strings.TrimSuffix "/") -}}
+{{- $baseURL := ($.Site.BaseURL | strings.TrimSuffix "/") -}}
 {{- $content = $content | replaceRE ` (href|src)="/` (printf ` $1="%s/` $baseURL) -}}
-{{- $content = $content | replaceRE ` (href|src)="#` (printf ` $1="%s#` $Deliver.Permalink) -}}
+{{- $content = $content | replaceRE ` (href|src)="#` (printf ` $1="%s#` $.Permalink) -}}
 {{- $content | safeHTML -}}

--- a/layouts/partials/utils/markdownify.html
+++ b/layouts/partials/utils/markdownify.html
@@ -1,9 +1,9 @@
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 {{- $Content := .raw -}}
 {{- $isContent := .isContent -}}
 
 <!-- New Markdown Syntax: Emphasis Point `..text..` -->
-{{- if $Deliver.Site.Params.enableEmphasisPoint -}}
+{{- if $.Site.Params.enableEmphasisPoint -}}
     {{- $regexPatternEmphasisPoint := `([^\.\x60])\.\.([^\.\s\n\/\\]+)\.\.([^\.\x60])` -}}
     {{- $regexReplacementEmphasisPoint := `$1<em class="emphasis-point">$2</em>$3` -}}
     {{- $Content = $Content | replaceRE $regexPatternEmphasisPoint $regexReplacementEmphasisPoint -}}
@@ -23,7 +23,7 @@
 {{- end -}}
 
 <!-- External Links -->
-{{- if $Deliver.Site.Params.hrefTargetBlank -}}
+{{- if $.Site.Params.hrefTargetBlank -}}
     {{- $Content = replaceRE `(<a href="https?:[^"]+")` `$1 target="_blank" rel="noopener"` $Content -}}
 {{- end -}}
 

--- a/layouts/partials/utils/open-graph.html
+++ b/layouts/partials/utils/open-graph.html
@@ -3,21 +3,21 @@
 <!-- https://developers.google.com/web/fundamentals/discovery/social-discovery/ -->
 <!-- https://stackoverflow.com/a/29831974 -->
 <!-- https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/opengraph.html -->
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 {{- $description := .description -}}
 <!-- Date -->
-{{- $dates := partial "utils/date.html" $Deliver -}}
+{{- $dates := partial "utils/date.html" $ -}}
 <!-- Images -->
-{{- $images := partial "utils/images.html" $Deliver -}}
+{{- $images := partial "utils/images.html" $ -}}
 
-<meta property="og:title" content="{{ (partial "utils/title.html" $Deliver).rawTitle }}" />
+<meta property="og:title" content="{{ (partial "utils/title.html" $).rawTitle }}" />
 <meta property="og:description" content="{{ $description }}" />
-<meta property="og:url" content="{{ $Deliver.Permalink }}" />
-<meta property="og:site_name" content="{{ $Deliver.Site.Title }}" />
-<meta property="og:locale" content="{{ $Deliver.Site.Language.Lang }}" />
-{{- if and $Deliver.Site.IsMultiLingual $Deliver.IsTranslated -}}
-    {{- range $Deliver.Site.Languages -}}
-        {{ if ne .Lang $Deliver.Site.Language.Lang }}
+<meta property="og:url" content="{{ $.Permalink }}" />
+<meta property="og:site_name" content="{{ $.Site.Title }}" />
+<meta property="og:locale" content="{{ $.Site.Language.Lang }}" />
+{{- if and $.Site.IsMultiLingual $.IsTranslated -}}
+    {{- range $.Site.Languages -}}
+        {{ if ne .Lang $.Site.Language.Lang }}
             <meta property="og:locale:alternate" content="{{ . }}" />
         {{ end }}
     {{- end -}}
@@ -26,19 +26,19 @@
 {{- with $images -}}
     <meta property="og:image" content="{{ index . 0 }}" />
 {{ else -}}
-    {{ with $Deliver.Site.Params.siteLogo -}}
+    {{ with $.Site.Params.siteLogo -}}
         <meta property="og:image" content="{{ . | absURL }}" />
     {{ end -}}
 {{- end -}}
 
-{{- if and $Deliver.IsPage (in $Deliver.Site.Params.mainSections $Deliver.Section) -}}
+{{- if and $.IsPage (in $.Site.Params.mainSections $.Section) -}}
     <meta property="og:type" content="article" />
     <meta property="article:published_time" content="{{ $dates.pubDate }}" />
     <meta property="article:modified_time" content="{{ $dates.modDate }}" />
-    {{ if not $Deliver.ExpiryDate.IsZero -}}
-        <meta property="article:expiration_time" content="{{ $Deliver.ExpiryDate.Format "2006-01-02T15:04:05-07:00" }}" />
+    {{ if not $.ExpiryDate.IsZero -}}
+        <meta property="article:expiration_time" content="{{ $.ExpiryDate.Format "2006-01-02T15:04:05-07:00" }}" />
     {{- end }}
-    <meta property="article:section" content="{{ $Deliver.Section }}" />
+    <meta property="article:section" content="{{ $.Section }}" />
 {{ else -}}
     <meta property="og:type" content="website" />
 {{- end }}

--- a/layouts/partials/utils/relative-url.html
+++ b/layouts/partials/utils/relative-url.html
@@ -1,8 +1,8 @@
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 {{- $filename := .filename -}}
 
 {{- $url := $filename -}}
-{{- $pathParts := split ($Deliver.RelPermalink | strings.TrimPrefix "/" | strings.TrimSuffix "/") "/" -}}
+{{- $pathParts := split ($.RelPermalink | strings.TrimPrefix "/" | strings.TrimSuffix "/") "/" -}}
 {{- range $pathParts -}}
     {{- with . -}}
         {{- $url = printf `../%s` $url -}}

--- a/layouts/partials/utils/tree-sections.html
+++ b/layouts/partials/utils/tree-sections.html
@@ -1,23 +1,23 @@
 <!-- Nested / Iteration / Recursion -->
 {{- $.Scratch.Delete "sections" -}}
 {{- $.Scratch.Delete "pages" -}}
-{{- $Deliver := . -}}
+{{- $ := . -}}
 {{- $contentDir := $.Site.Params.contentDir -}}
-{{- template "treeSections" (dict "Deliver" $Deliver "path" (cond $.Site.IsMultiLingual (printf `./%s` $contentDir) (printf `./content`))) -}}
+{{- template "treeSections" (dict "$" $ "path" (cond $.Site.IsMultiLingual (printf `./%s` $contentDir) (printf `./content`))) -}}
 {{- define "treeSections" -}}
-    {{- $Deliver := .Deliver -}}
+    {{- $ := index . "$" -}}
     {{- $path := .path -}}
     {{- range (readDir $path) -}}
         {{- $fileName := .Name -}}
         {{- if .IsDir -}}
-            {{- $pagePath := (cond $Deliver.Site.IsMultiLingual (strings.TrimPrefix (printf `./%s` $Deliver.Site.Params.contentDir) (printf `%s/%s` $path $fileName)) (strings.TrimPrefix "./content" (printf `%s/%s` $path $fileName))) -}}
-            {{- with $Deliver.Site.GetPage $pagePath -}}
-                {{- if and (eq .Kind "section") (in $Deliver.Site.Params.mainSections .Section) -}}
-                    {{- $Deliver.Scratch.Add "sections" (printf "%s, " $fileName) -}}
-                    {{- $Deliver.Scratch.SetInMap "pages" $pagePath $fileName -}}
+            {{- $pagePath := (cond $.Site.IsMultiLingual (strings.TrimPrefix (printf `./%s` $.Site.Params.contentDir) (printf `%s/%s` $path $fileName)) (strings.TrimPrefix "./content" (printf `%s/%s` $path $fileName))) -}}
+            {{- with $.Site.GetPage $pagePath -}}
+                {{- if and (eq .Kind "section") (in $.Site.Params.mainSections .Section) -}}
+                    {{- $.Scratch.Add "sections" (printf "%s, " $fileName) -}}
+                    {{- $.Scratch.SetInMap "pages" $pagePath $fileName -}}
                 {{- end -}}
             {{- end -}}
-            {{- template "treeSections" (dict "Deliver" $Deliver "path" (printf `%s/%s` $path $fileName)) -}}
+            {{- template "treeSections" (dict "$" $ "path" (printf `%s/%s` $path $fileName)) -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/layouts/partials/utils/tree-sections.html
+++ b/layouts/partials/utils/tree-sections.html
@@ -1,7 +1,6 @@
 <!-- Nested / Iteration / Recursion -->
 {{- $.Scratch.Delete "sections" -}}
 {{- $.Scratch.Delete "pages" -}}
-{{- $ := . -}}
 {{- $contentDir := $.Site.Params.contentDir -}}
 {{- template "treeSections" (dict "$" $ "path" (cond $.Site.IsMultiLingual (printf `./%s` $contentDir) (printf `./content`))) -}}
 {{- define "treeSections" -}}

--- a/layouts/partials/utils/twitter-cards.html
+++ b/layouts/partials/utils/twitter-cards.html
@@ -1,11 +1,11 @@
 <!-- https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started -->
 <!-- https://cards-dev.twitter.com/validator -->
 <!-- https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/twitter_cards.html -->
-{{- $Deliver := .Deliver -}}
+{{- $ := index . "$" -}}
 <!-- Author -->
-{{- $author := partial "utils/author.html" $Deliver -}}
+{{- $author := partial "utils/author.html" $ -}}
 <!-- Images -->
-{{- $images := partial "utils/images.html" $Deliver -}}
+{{- $images := partial "utils/images.html" $ -}}
 
 {{- with $images -}}
     <meta name="twitter:card" content="summary_large_image" />
@@ -13,7 +13,7 @@
     <meta name="twitter:card" content="summary" />
 {{- end }}
 
-{{ with $Deliver.Site.Params.siteTwitter -}}
+{{ with $.Site.Params.siteTwitter -}}
     <meta name="twitter:site" content="@{{ . }}" />
 {{ end -}}
 {{ with $author.twitter -}}


### PR DESCRIPTION
For most part, this is an automated search & replace:

* `$Deliver` => `$`
* `"Deliver"` => `"$"`
* `$ := .Deliver` => `$ := index . "$"`

The only manual changes are in `assets/js/lunr-search.js` and `layouts/partials/utils/list-item.html`.