### PR TITLE
refactor: Do not rely on HTML code manipulation in JavaScript

### DIFF
--- a/assets/js/copy.js
+++ b/assets/js/copy.js
@@ -9,7 +9,9 @@ window.addEventListener("DOMContentLoaded", event => {
     const copiedText = '{{ i18n "copied" }}';
 
     document.querySelectorAll('.post-body > pre').forEach((e) => {
-        e.outerHTML = `<div style="position: relative">${e.outerHTML}</div>`;
+        let div = document.createElement('div');
+        e.parentNode.replaceChild(div, e);
+        div.appendChild(e);
     });
 
     function addCopyButtons(clipboard) {

--- a/assets/js/wrap-table.js
+++ b/assets/js/wrap-table.js
@@ -1,8 +1,0 @@
-// Wrap `<table>` to make it responsive
-// Reference: https://github.com/stone-zeng/stone-zeng.github.io/blob/master/js/script.js
-
-window.addEventListener("DOMContentLoaded", event => {
-    document.querySelectorAll('table').forEach((e) => {
-        e.outerHTML = `<div class="table-container">${e.outerHTML}</div>`;
-    });
-}, {once: true});

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -24,8 +24,6 @@
     {{- $scripts = union $scripts (slice "js/multilingual.js") -}}
 {{- end -}}
 
-{{- $scripts = union $scripts (slice "js/wrap-table.js") -}}
-
 {{- if .Site.Params.enableCopy -}}
     {{- $scripts = union $scripts (slice "js/copy.js") -}}
 {{- end -}}

--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -185,6 +185,10 @@
     {{- end -}}
 {{- end -}}
 
+<!-- Responsive tables -->
+{{- $Content = $Content | replaceRE `<table\b` `<div class="table-container"><table` -}}
+{{- $Content = $Content | replaceRE `</table>` `</table></div>` -}}
+
 <!-- Custom -->
 {{- $Content = partial "custom/content.html" (dict "$" $ "Content" $Content) | default $Content -}}
 


### PR DESCRIPTION
`innerHTML`/`outerHTML` usage generally raises security flags, these are common sources of XSS vulnerabilities. Even through `outerHTML` usage in MemE is easily identified as unproblematic, its performance is still suboptimal (DOM tree has to be serialized to HTML code and parsed back again) and it could cause further issues if JavaScript code attaches some state (e.g. event handlers) to elements which are being thrown away and replaced.

For table wrapping, JavaScript is completely unnecessary - this replacement can be done at generation time.

Things are somewhat more complicated with the copy buttons. Since only top-level `<pre>` tags need to be wrapped, it's hard to achieve this when the page is generated. So my code is doing proper DOM manipulation. Note that `style="position: relative"` is unnecessary for the `<div>` wrapper element, `addCopyButtons()` below will add it.