### PR TITLE
fix: Safari doesn't support addEventListener on media queries

### DIFF
--- a/assets/js/nav-toggle.js
+++ b/assets/js/nav-toggle.js
@@ -63,12 +63,12 @@ window.addEventListener("DOMContentLoaded", event => {
     const maxWidth = window.getComputedStyle(document.documentElement, null).getPropertyValue('--max-width');
     let mediaQuery = window.matchMedia(`(max-width: ${maxWidth})`);
 
-    mediaQuery.addEventListener('change', e => {
+    mediaQuery.addListener(e => {
         if (!e.matches) {
             // We are no longer in responsive mode, close nav
             closeNav(true);
         }
-    })
+    });
 
 
     function checkInput() {


### PR DESCRIPTION
This *might* be the reason why theme switcher was reported to be broken (https://github.com/reuixiy/hugo-theme-meme/issues/181#issuecomment-635374813). In my testing this error didn't affect any unrelated functionality however.