### PR TITLE
refactor: Make title.html partial more readable, fix title for taxonomy pages

### DIFF
--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -3,14 +3,15 @@
         {{- if gt $index 0 -}}
             ,
         {{- end -}}
-        {{- $entry := dict "uri" $page.RelPermalink "title" $page.Title "content" ($page.Plain | htmlUnescape) -}}
+        {{- $rawTitle := (partial "utils/title.html" (dict "$" $ "title" $page.Title)).rawTitle -}}
+        {{- $entry := dict "uri" $page.RelPermalink "title" $rawTitle "content" ($page.Plain | htmlUnescape) -}}
         {{- if $page.Params.subtitle -}}
             {{- $subtitle := partial "utils/markdownify.html" (dict "$" $page "raw" $page.Params.subtitle "isContent" false) -}}
-            {{- $entry = merge $entry (dict "subtitle" ($subtitle | plainify)) -}}
+            {{- $entry = merge $entry (dict "subtitle" ($subtitle | plainify | htmlUnescape)) -}}
         {{- end -}}
         {{- if .Site.Params.displayPostDescription -}}
             {{- $description := partial "utils/markdownify.html" (dict "$" $page "raw" $page.Description "isContent" false) -}}
-            {{- $entry = merge $entry (dict "description" ($description | plainify)) -}}
+            {{- $entry = merge $entry (dict "description" ($description | plainify | htmlUnescape)) -}}
         {{- end -}}
         {{- if .Site.Params.displayCategory -}}
             {{- if eq .Site.Params.categoryBy "sections" -}}

--- a/layouts/partials/utils/title.html
+++ b/layouts/partials/utils/title.html
@@ -1,30 +1,29 @@
 {{- $ := index . "$" -}}
-{{- $rawTitle := .title -}}
+{{- $htmlTitle := .title -}}
 <!-- Home -->
 {{- if eq $.Kind "home" -}}
-    {{- $rawTitle = $rawTitle | default $.Site.Title -}}
+    {{- $htmlTitle = $htmlTitle | default $.Site.Title -}}
 <!-- Taxonomy -->
 {{- else if eq $.Kind "taxonomyTerm" -}}
-    {{- $rawTitle = $rawTitle | default ($.Type | title) -}}
+    {{- $htmlTitle = $htmlTitle | default ($.Type | title) -}}
 <!-- Taxonomy Term -->
 {{- else if eq $.Kind "taxonomy" -}}
-    {{- $taxonomyTermTitle := $rawTitle | default $.Data.Term | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" $.Path) "/")) " ") -}}
+    {{- $taxonomyTermTitle := $htmlTitle | default $.Data.Term | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" $.Path) "/")) " ") -}}
     {{- with $.Site.GetPage (printf "/%s" $.Data.Plural) -}}
-        {{- $rawTitle = printf "%s: %s" ($.Title | default ($.Type | title)) $taxonomyTermTitle -}}
+        {{- $htmlTitle = printf "%s: %s" (.Title | default (.Type | title)) $taxonomyTermTitle -}}
     {{- end -}}
 <!-- Section -->
 {{- else if eq $.Kind "section" -}}
-    {{- $rawTitle = $rawTitle | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" $.Path) "/")) " ") -}}
-<!-- Page -->
-{{- else -}}
-    {{- $rawTitle = $rawTitle -}}
+    {{- $htmlTitle = $htmlTitle | default (delimit (last 1 (split (strings.TrimSuffix "/_index.md" $.Path) "/")) " ") -}}
 {{- end -}}
 
-{{- $htmlTitle := partial "utils/markdownify.html" (dict "$" $ "raw" $rawTitle "isContent" false) -}}
+{{- $htmlTitle = partial "utils/markdownify.html" (dict "$" $ "raw" $htmlTitle "isContent" false) -}}
 
-{{- $title := $htmlTitle -}}
+{{- $rawTitle := $htmlTitle | plainify | htmlUnescape -}}
+
+{{- $title := $rawTitle -}}
 {{- if ne $.Kind "home" -}}
     {{- $title = printf "%s | %s" $title $.Site.Title -}}
 {{- end -}}
 
-{{- return dict "rawTitle" ($htmlTitle | plainify | htmlUnescape) "title" ($title | plainify | htmlUnescape) "htmlTitle" $htmlTitle -}}
+{{- return dict "rawTitle" $rawTitle "title" $title "htmlTitle" $htmlTitle -}}


### PR DESCRIPTION
As mentioned in https://github.com/reuixiy/hugo-theme-meme/pull/183#discussion_r433662953, I renamed the variables to make the logic more clear. I also fixed the title for taxonomy pages (#183 introduced a bug, making it "security: security" instead of "Categories: security") and removed unnecessary code (massaging the title for regular pages no longer necessary).

Finally, I added a "BREAKING CHANGE" note to this commit because #183 didn't. I checked the output for my blog, there are lots of changes, mostly due to the typographer extension now doing its job on the titles. In my case these changes all seem unproblematic.