### PR TITLE
fix: Avoid double escaping when using post description

### DIFF
--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -6,11 +6,11 @@
         {{- $entry := dict "uri" $page.RelPermalink "title" $page.Title "content" ($page.Plain | htmlUnescape) -}}
         {{- if $page.Params.subtitle -}}
             {{- $subtitle := partial "utils/markdownify.html" (dict "$" $page "raw" $page.Params.subtitle "isContent" false) -}}
-            {{- $entry = merge $entry (dict "subtitle" ($subtitle | plainify)) -}}
+            {{- $entry = merge $entry (dict "subtitle" ($subtitle | plainify | htmlUnescape )) -}}
         {{- end -}}
         {{- if .Site.Params.displayPostDescription -}}
             {{- $description := partial "utils/markdownify.html" (dict "$" $page "raw" $page.Description "isContent" false) -}}
-            {{- $entry = merge $entry (dict "description" ($description | plainify)) -}}
+            {{- $entry = merge $entry (dict "description" ($description | plainify | htmlUnescape)) -}}
         {{- end -}}
         {{- if .Site.Params.displayCategory -}}
             {{- if eq .Site.Params.categoryBy "sections" -}}

--- a/layouts/index.sectionsatom.xml
+++ b/layouts/index.sectionsatom.xml
@@ -26,7 +26,7 @@
         </author>
     {{- end }}
     {{ with .Site.Copyright -}}
-        <rights>{{ . | plainify }}</rights>
+        <rights>{{ . | plainify | htmlUnescape }}</rights>
     {{- end }}
     <generator uri="https://gohugo.io/" version="{{ hugo.Version }}">Hugo</generator>
     {{- range (where $pages "Section" "in" .Site.Params.mainSections) }}
@@ -52,7 +52,7 @@
                 </author>
             {{- end }}
             {{ with $author.copyright -}}
-                <rights>{{ . | plainify }}</rights>
+                <rights>{{ . | plainify | htmlUnescape }}</rights>
             {{- end }}
             {{- $summary := .Description | default (partial "utils/summary.html" $page) -}}
             <summary type="html">{{ partial "utils/make-links-absolute.html" (dict "$" . "content" $summary) | html }}</summary>

--- a/layouts/index.sectionsrss.xml
+++ b/layouts/index.sectionsrss.xml
@@ -26,7 +26,7 @@
             <webMaster>{{ . }}{{ with $.Site.Author.name }} ({{ . }}){{ end }}</webMaster>
         {{ end }}
         {{ with .Site.Copyright }}
-            <copyright>{{ . | plainify }}</copyright>
+            <copyright>{{ . | plainify | htmlUnescape }}</copyright>
         {{ end }}
         <lastBuildDate>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</lastBuildDate>
         {{ with .OutputFormats.Get "SectionsRSS" }}
@@ -44,7 +44,7 @@
                     <author>{{ . }}{{ with $author.name }} ({{ . }}){{ end }}</author>
                 {{ end }}
                 {{ with $author.copyright -}}
-                    <copyright>{{ . | plainify }}</copyright>
+                    <copyright>{{ . | plainify | htmlUnescape }}</copyright>
                 {{- end }}
                 {{ if $.Site.Params.includeContent }}
                     <description>{{ partial "utils/make-links-absolute.html" (dict "$" . "content" .Content) | html }}</description>

--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -2,7 +2,7 @@
 
     {{- $title := (partial "utils/title.html" (dict "$" . "title" .Title)).rawTitle -}}
 
-    {{- $description := .Description | default (partial "utils/summary.html" .) | default .Site.Params.siteDescription | plainify -}}
+    {{- $description := .Description | default (partial "utils/summary.html" .) | default .Site.Params.siteDescription | plainify | htmlUnescape -}}
 
     {{- $images := partial "utils/images.html" . -}}
     {{- $images = union $images (slice (.Site.Params.siteLogo | absURL)) -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,7 +37,7 @@
     {{- end }}
 
     <meta name="author" content="{{ .Params.author | default .Site.Author.name }}" />
-    {{- $description := .Description | default (partial "utils/summary.html" .) | default .Site.Params.siteDescription | plainify -}}
+    {{- $description := .Description | default (partial "utils/summary.html" .) | default .Site.Params.siteDescription | plainify | htmlUnescape -}}
     <meta name="description" content="{{ $description }}" />
 
     <!-- Favicon, Icons, Web App -->

--- a/layouts/partials/utils/json-ld.html
+++ b/layouts/partials/utils/json-ld.html
@@ -29,7 +29,7 @@
         "author": {
             "@type": "Person",
             {{ with .motto -}}
-            "description": {{ . | plainify }},
+            "description": {{ . | plainify | htmlUnescape }},
             {{ end -}}
             {{ with .email -}}
             "email": {{ . }},
@@ -46,7 +46,7 @@
         },
         {{ end -}}
         {{ with $author.copyright -}}
-        "license": {{ . | plainify }},
+        "license": {{ . | plainify | htmlUnescape }},
         {{ end -}}
         "name": {{ $rawTitle }}
     }
@@ -75,7 +75,7 @@
         "author": {
             "@type": "Person",
             {{ with .motto -}}
-            "description": {{ . | plainify }},
+            "description": {{ . | plainify | htmlUnescape }},
             {{ end -}}
             {{ with .email -}}
             "email": {{ . }},
@@ -92,7 +92,7 @@
         },
         {{ end -}}
         {{ with $author.copyright -}}
-        "license": {{ . | plainify }},
+        "license": {{ . | plainify | htmlUnescape }},
         {{ end -}}
         "publisher": {
             "@type": "Organization",
@@ -129,7 +129,7 @@
         {{ end -}}
         {{ end -}}
         {{ with $author.copyright -}}
-        "license": {{ . | plainify }},
+        "license": {{ . | plainify | htmlUnescape }},
         {{ end -}}
         "publisher": {
             "@type": "Organization",


### PR DESCRIPTION
I noticed an issue when a description is deduced from a post starting with something like `It's a nice weather outside.` The typographer Goldmark extension turns this into `It&rsquo;s a nice weather outside.` and I see this entity escaped twice in the meta tag then. It seems that `| plainify` should always be applied in connection with `| htmlUnescape`.