### PR TITLE
fix: Search index should include sections & co. if these have content

### DIFF
--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -1,5 +1,5 @@
 [
-    {{- range $index, $page := .Site.RegularPages -}}
+    {{- range $index, $page := where .Site.Pages "Content" "ne" ("" | safeHTML)  -}}
         {{- if gt $index 0 -}}
             ,
         {{- end -}}


### PR DESCRIPTION
I noticed that only including regular pages in the search index isn't a good idea - I have pages like "privacy policy" which are actually sections. So now any page with content is included.