### PR TITLE
fix: Allow scripts and styles to load cross-origin, e.g. from Google Translate

### DIFF
--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -1272,6 +1272,17 @@ uglyURLs = false
     # Note: valid for CSS and JS generated
     #       by MemE only
 
+    enableSRI = false
+    # Note: subresource integrity will
+    #       block MemE CSS and JS on third
+    #       party websites like Google
+    #       Translate. To prevent this,
+    #       your server has to send the
+    #       following header for CSS and
+    #       JS requests:
+    #
+    #       Access-Control-Allow-Origin: *
+
 
     ######################################
     # Force HTTPS Redirection

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -52,7 +52,7 @@
 
 {{- if .Site.Params.enableFingerprint -}}
     {{- $script := $processedScripts | resources.Concat $path | resources.Minify | resources.Fingerprint -}}
-    <script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity }}"></script>
+    <script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity }}" crossorigin="anonymous"></script>
 {{- else -}}
     {{- $script := $processedScripts | resources.Concat $path | resources.Minify -}}
     <script src="{{ $script.RelPermalink }}"></script>

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -50,10 +50,12 @@
 
 {{- $path := (strings.TrimPrefix "/" (printf `%s/js/meme.js` .Site.LanguagePrefix)) -}}
 
+{{- $script := $processedScripts | resources.Concat $path | resources.Minify -}}
 {{- if .Site.Params.enableFingerprint -}}
-    {{- $script := $processedScripts | resources.Concat $path | resources.Minify | resources.Fingerprint -}}
-    <script src="{{ $script.RelPermalink }}" integrity="{{ $script.Data.Integrity }}" crossorigin="anonymous"></script>
+    {{- $script = $script | resources.Fingerprint -}}
+    <script src="{{ $script.RelPermalink }}"
+    {{- if .Site.Params.enableSRI }} integrity="{{ $script.Data.Integrity }}" crossorigin="anonymous"{{- end -}}
+    ></script>
 {{- else -}}
-    {{- $script := $processedScripts | resources.Concat $path | resources.Minify -}}
     <script src="{{ $script.RelPermalink }}"></script>
 {{- end }}

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -3,7 +3,7 @@
 
 {{- if .Site.Params.enableFingerprint -}}
     {{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate (printf "%s/styles/main-rendered.scss" .Lang) . | resources.ToCSS $options | resources.Fingerprint -}}
-    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" />
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
 {{- else -}}
     {{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate (printf "%s/styles/main-rendered.scss" .Lang) . | resources.ToCSS $options -}}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" />

--- a/layouts/partials/style.html
+++ b/layouts/partials/style.html
@@ -1,10 +1,12 @@
 {{- $path := (strings.TrimPrefix "/" (printf `%s/css/meme.min.css` .Site.LanguagePrefix)) -}}
 {{- $options := (dict "targetPath" $path "outputStyle" "compressed") -}}
 
+{{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate (printf "%s/styles/main-rendered.scss" .Lang) . | resources.ToCSS $options -}}
 {{- if .Site.Params.enableFingerprint -}}
-    {{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate (printf "%s/styles/main-rendered.scss" .Lang) . | resources.ToCSS $options | resources.Fingerprint -}}
-    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous" />
+    {{- $style = $style | resources.Fingerprint -}}
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}"
+    {{- if .Site.Params.enableSRI }} integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous"{{- end -}}
+    />
 {{- else -}}
-    {{- $style := resources.Get "scss/main.scss" | resources.ExecuteAsTemplate (printf "%s/styles/main-rendered.scss" .Lang) . | resources.ToCSS $options -}}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}" />
 {{- end -}}


### PR DESCRIPTION
I noticed that neither scripts nor styles of my websites were loading when somebody attempted to translate an article via Google Translate. That's due to `enableFingerprint = true` configuration option - it doesn't merely enable fingerprinting but also Subresource Integrity. Turns out, cross-origin requests with `integrity` attribute are blocked by default, otherwise these could be [misused to leak information](https://bugs.chromium.org/p/chromium/issues/detail?id=812667).

The solution consists of two parts:

1. Add `crossorigin="anonymous"` attribute to the requests in question (done here).
2. Add `Access-Control-Allow-Origin: *` header to JS/CSS requests - has to be done in server configuration.

The second part probably needs documenting. The other option would be to separate fingerprinting (useful by itself to avoid using outdated scripts/styles) and Subresource Integrity in the configuration.