### PR TITLE
Fix: display correctly month if languageCode ne EN

### DIFF
--- a/layouts/partials/utils/list-item.html
+++ b/layouts/partials/utils/list-item.html
@@ -15,7 +15,16 @@
         {{ range . }}
             <li class="list-item">
                 <a href="{{ .RelPermalink }}" class="list-item-title">{{ (partial "utils/title.html" (dict "$" . "title" .LinkTitle)).htmlTitle }}</a>
-                <time datetime="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="list-item-time">{{ .PublishDate.Format .Site.Params.listDateFormat }}</time>
+                <time datetime="{{ .PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="list-item-time">
+					{{ if .Site.Params.i18nMonth }}
+						{{ $month := .PublishDate.Format "January" }}{{ $month := i18n (lower $month) }}
+						{{ $day := .PublishDate.Format "2" }}
+						{{ if eq .Site.LanguageCode "fr" }}{{ $day }}{{ if eq $day "1" }}<sup>er</sup>{{ end }} {{ $month }}
+						{{ else }}{{ $month }} {{ $day }}{{ end }}
+					{{ else }}
+						{{ .PublishDate.Format .Site.Params.listDateFormat }}
+					{{ end }}
+                </time>
             </li>
         {{ end }}
         {{ if and (gt $limit 0) (gt (len $.Pages) $limit) }}


### PR DESCRIPTION
if i18n exists, the month into this list item is not correctly displayed. Actually, only in english.
With this fixe, month is displayed segun language code.