### PR TITLE
feat: Adjust post markup to conform to h-entry spec

### DIFF
--- a/layouts/partials/components/post-copyright.html
+++ b/layouts/partials/components/post-copyright.html
@@ -4,9 +4,9 @@
         <ul class="post-copyright">
             <li class="copyright-item author">
                 {{- with $author.website -}}
-                    <span class="copyright-item-text">{{ i18n "copyrightAuthor" }}</span>{{ i18n "colon" }}<a href="{{ . }}" target="_blank" rel="noopener">{{ $author.name }}</a>
+                    <span class="copyright-item-text">{{ i18n "copyrightAuthor" }}</span>{{ i18n "colon" }}<a href="{{ . }}" class="p-author h-card" target="_blank" rel="noopener">{{ $author.name }}</a>
                 {{- else -}}
-                    <span class="copyright-item-text">{{ i18n "copyrightAuthor" }}</span>{{ i18n "colon" }}{{ $author.name }}
+                    <span class="copyright-item-text">{{ i18n "copyrightAuthor" }}</span>{{ i18n "colon" }}<span class="p-author h-card">{{ $author.name }}</span>
                 {{- end -}}
             </li>
             {{ if $.Params.original | default $.Site.Params.original }}

--- a/layouts/partials/components/post-meta.html
+++ b/layouts/partials/components/post-meta.html
@@ -3,11 +3,11 @@
 <div class="post-meta">
     {{ if and $.Site.Params.displayPublishedDate (not $.PublishDate.IsZero) }}
         {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.publishedDateIcon "class" "post-meta-icon") }}
-        <time datetime="{{ $.PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item published">{{ $icon }}&nbsp;{{ $.PublishDate.Format $.Site.Params.postMetaDateFormat }}</time>
+        <time datetime="{{ $.PublishDate.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item published dt-published">{{ $icon }}&nbsp;{{ $.PublishDate.Format $.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
     {{ if and $.Site.Params.displayModifiedDate (not $.Lastmod.IsZero) }}
         {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.modifiedDateIcon "class" "post-meta-icon") }}
-        <time datetime="{{ $.Lastmod.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item modified">{{ $icon }}&nbsp;{{ $.Lastmod.Format $.Site.Params.postMetaDateFormat }}</time>
+        <time datetime="{{ $.Lastmod.Format "2006-01-02T15:04:05-07:00" }}" class="post-meta-item modified dt-updated">{{ $icon }}&nbsp;{{ $.Lastmod.Format $.Site.Params.postMetaDateFormat }}</time>
     {{ end }}
     {{ if and $.Site.Params.displayExpiredDate (not $.ExpiryDate.IsZero) }}
         {{ $icon := partial "utils/icon.html" (dict "$" $ "name" $.Site.Params.expiredDateIcon "class" "post-meta-icon") }}
@@ -41,7 +41,7 @@
                         {{- if ne $index 0 }}
                             {{- $.Site.Params.categoryDelimiter | default "/" -}}
                         {{- end -}}
-                        <a href="{{- $link | replaceRE `\d+/(.+)` `$1` -}}" class="category-link">
+                        <a href="{{- $link | replaceRE `\d+/(.+)` `$1` -}}" class="category-link p-category">
                             {{- $title -}}
                         </a>
                     {{- end -}}
@@ -59,7 +59,7 @@
                         <!-- Work-around for https://github.com/gohugoio/hugo/issues/6546 -->
                         {{- $path := (urls.Parse ($category | urlize)).Path -}}
                         {{- with $.Site.GetPage (printf `/categories/%s` $path) -}}
-                            <a href="{{- .RelPermalink -}}" class="category-link">
+                            <a href="{{- .RelPermalink -}}" class="category-link p-category">
                                 {{- .LinkTitle | default $path -}}
                             </a>
                         {{- end -}}

--- a/layouts/partials/pages/home-posts.html
+++ b/layouts/partials/pages/home-posts.html
@@ -2,14 +2,14 @@
     <div class="main-inner">
         {{ $paginator := .Paginate (where .Site.RegularPages "Section" "in" .Site.Params.mainSections) }}
         {{ range $paginator.Pages }}
-            <article class="content post home">
-                <h2 class="post-title">
-                    <a href="{{ .RelPermalink }}" class="summary-title-link">{{ (partial "utils/title.html" (dict "$" . "title" .LinkTitle)).htmlTitle }}</a>
+            <article class="content post home h-entry">
+                <h2 class="post-title p-name">
+                    <a href="{{ .RelPermalink }}" class="summary-title-link u-url">{{ (partial "utils/title.html" (dict "$" . "title" .LinkTitle)).htmlTitle }}</a>
                 </h2>
                 {{ if $.Site.Params.enablePostMetaInHome }}
                     {{ partial "components/post-meta.html" (dict "$" . "isHome" true) }}
                 {{ end }}
-                <summary class="summary">
+                <summary class="summary p-summary">
                     {{ partial "utils/summary.html" . }}
                 </summary>
                 {{ if or .Truncated .Params.summary }}

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -3,7 +3,7 @@
 
         {{ $attrs := partial "utils/data-attributes.html" . }}
 
-        <article class="content post"
+        <article class="content post h-entry"
         {{- if $attrs.smallCaps }} data-small-caps="true"{{ end }}
         {{- with $attrs.align }} data-align="{{ . }}"{{ end }}
         {{- with $attrs.type }} data-type="{{ . }}"{{ end }}
@@ -11,17 +11,17 @@
         {{- if $attrs.indent }} data-indent="true"{{ end }}
         {{- if $attrs.tocNum }} data-toc-num="true"{{ end }}>
 
-            <h1 class="post-title">{{ (partial "utils/title.html" (dict "$" $ "title" $.Title)).htmlTitle }}</h1>
+            <h1 class="post-title p-name">{{ (partial "utils/title.html" (dict "$" $ "title" $.Title)).htmlTitle }}</h1>
 
             {{ with .Params.subtitle }}
                 {{- $raw := . -}}
-                <div class="post-subtitle">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
+                <div class="post-subtitle p-name">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
             {{ end }}
 
             {{ if .Site.Params.displayPostDescription }}
                 {{ with .Params.description }}
                     {{- $raw := . -}}
-                    <div class="post-description">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
+                    <div class="post-description p-summary">{{ partial "utils/markdownify.html" (dict "$" $ "raw" $raw "isContent" false) }}</div>
                 {{ end }}
             {{ end }}
 
@@ -34,7 +34,7 @@
                 {{- partial "utils/toc.html" . -}}
             {{- end -}}
 
-            <div class="post-body">
+            <div class="post-body e-content">
               {{ partial "utils/content.html" . }}
             </div>
 

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -38,13 +38,13 @@
               {{ partial "utils/content.html" . }}
             </div>
 
+            {{ partial "components/post-copyright.html" . }}
+
         </article>
 
         {{ if and .Site.Params.enableGoogleAdUnits (eq hugo.Environment "production") -}}
             {{ partial "third-party/google-adsense-unit.html" . }}
         {{- end }}
-
-        {{ partial "components/post-copyright.html" . }}
 
         {{ partial "components/post-updated-badge.html" . }}
 


### PR DESCRIPTION
This adds a bunch of class names according to the [h-entry spec](http://microformats.org/wiki/h-entry). It allows the contents to be parsed semantically by microformats parser, e.g. https://python.microformats.io/. This is useful for example for [Webmention receivers](https://www.w3.org/TR/webmention/) – these prefer to have useful data about a page rather than merely its URL.

The significant missing part here is `p-author`, MemE simply doesn't display an author for each post.