### PR TITLE
fix: add tinyseg.js to scripts if japanese

### DIFF
--- a/layouts/partials/third-party/lunr-search.html
+++ b/layouts/partials/third-party/lunr-search.html
@@ -3,7 +3,7 @@
     {{- $supported := slice "ar" "da" "de" "du" "es" "fi" "fr" "hu" "it" "ja" "nl" "no" "pt" "ro" "ru" "sv" "tr" "vi" -}}
     {{- if in $supported .Site.Language.Lang -}}
         {{- if eq .Site.Language.Lang "ja" -}}
-        {{- $scripts = union $scripts (slice "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/tinyseg.js") -}}
+            {{- $scripts = union $scripts (slice "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/tinyseg.js") -}}
         {{- end -}}
         {{- $scripts = union $scripts (slice "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.stemmer.support.min.js") -}}
         {{- $scripts = union $scripts (slice (printf "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.%s.min.js" .Site.Language.Lang)) -}}

--- a/layouts/partials/third-party/lunr-search.html
+++ b/layouts/partials/third-party/lunr-search.html
@@ -2,6 +2,9 @@
 {{- if ne .Site.Language.Lang "en" -}}
     {{- $supported := slice "ar" "da" "de" "du" "es" "fi" "fr" "hu" "it" "ja" "nl" "no" "pt" "ro" "ru" "sv" "tr" "vi" -}}
     {{- if in $supported .Site.Language.Lang -}}
+        {{- if eq .Site.Language.Lang "ja" -}}
+        {{- $scripts = union $scripts (slice "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/tinyseg.js") -}}
+        {{- end -}}
         {{- $scripts = union $scripts (slice "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.stemmer.support.min.js") -}}
         {{- $scripts = union $scripts (slice (printf "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.%s.min.js" .Site.Language.Lang)) -}}
     {{- else -}}


### PR DESCRIPTION
when
```toml
defaultContentLanguage = "ja"
```
lunr is not working since lunr.ja.min.js raises an error.

lunr.ja.min.js requires tinyseg.js.

https://github.com/MihaiValentin/lunr-languages/blob/master/demos/demo-browser-require-ja.html#L11

