### PR TITLE
[Update] Modify start_url to meet the PWA's fast and reliable requirment

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -12,5 +12,5 @@
     "background_color": "#fff",
     "display": "standalone",
     "orientation": "portrait-primary",
-    "start_url": "./?utm_source=homescreen"
+    "start_url": "/"
 }


### PR DESCRIPTION
I found the current `manifest.json` missed the requirement of `Fast and reliable` in PWA.

You can get more information in this [link](https://web.dev/works-offline/)

And here is the report of `io-oi.me` with [manifest.json](https://io-oi.me/manifest.json)

![image](https://user-images.githubusercontent.com/32964977/110213519-660d0900-7edb-11eb-8b34-9effc1faf83a.png)

I used this [manifest.json](https://www.zhangjc.site/manifest.json) and it meets this requirement.

![image](https://user-images.githubusercontent.com/32964977/110213434-f7c84680-7eda-11eb-8f15-6d040aa503ea.png)

Also, for those whose homepage is not hosted on the root path, one can refer to this [link](https://www.coder.work/article/938443) to work with the `scope` parameter.
