### PR TITLE
Add support for Yandex.Metrika

### DIFF
--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -712,6 +712,16 @@ uglyURLs = false
 
 
     ######################################
+    # Yandex.Metrika
+    # https://metrika.yandex.ru/
+
+    # Note: render only in production
+    #       environment
+
+    yandexMetrikaId = ""
+
+
+    ######################################
     # Post Settings
 
     # The color change duration of the

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -659,6 +659,15 @@ uglyURLs = false
 
 
     ######################################
+    # Yandex.Metrika
+    # https://metrika.yandex.ru/
+
+    # 说明：仅在生产环境（production）下渲染
+
+    yandexMetrikaId = ""
+
+
+    ######################################
     # 文章设置
 
     # 超链接的颜色变化持续时间（单位：秒）

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -659,6 +659,15 @@ uglyURLs = false
 
 
     ######################################
+    # Yandex.Metrika
+    # https://metrika.yandex.ru/
+
+    # 說明：僅在生產環境（production）下渲染
+
+    yandexMetrikaId = ""
+
+
+    ######################################
     # 文章設定
 
     # 超連結的顏色變化持續時間（單位：秒）

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -1,0 +1,169 @@
+[ellipsis]
+other = "…"
+
+[colon]
+other = ": "
+
+[minute]
+one = "мин"
+other = "мин"
+
+[tocTitle]
+other = "Содержание"
+
+[readMore]
+other = "Читать далее"
+
+[prevPage]
+other = "Новые"
+
+[nextPage]
+other = "Старые"
+
+[copy]
+other = "Копировать"
+
+[copied]
+other = "Скопировано!"
+
+[copyrightAuthor]
+other = "Автор"
+
+[copyrightLink]
+other = "Ссылка"
+
+[copyrightLicense]
+other = "Лицензия"
+
+[shareOn]
+other = "Поделиться:"
+
+[shareOnTitle]
+other = "Поделиться "
+
+[shareViaTitle]
+other = "Поделиться "
+
+[relatedPosts]
+other = "Ещё:"
+
+[loadComments]
+other = "Загрузить комментарии?"
+
+[pageNotFound]
+other = "404 - Страница не найдена"
+
+[fofLinkText]
+other = "Домой"
+
+[searchResultsTitle]
+one = "Найден один результат для “{{ .Term }}”"
+other = "Найдено {{ .Count }} результатов для “{{ .Term }}”"
+
+[searchResultsNone]
+other = "Ничего не найдено для “{{ .Term }}”"
+
+
+# Socials
+
+[twitter]
+other = "Twitter"
+
+[facebook]
+other = "Facebook"
+
+[linkedin]
+other = "LinkedIn"
+
+[telegram]
+other = "Telegram"
+
+[weibo]
+other = "Weibo"
+
+[douban]
+other = "Douban"
+
+[qq]
+other = "QQ"
+
+[qzone]
+other = "Qzone"
+
+[qrcode]
+other = "QR Code"
+
+
+# Months
+# Used for `i18nMonth`
+
+[january]
+other = "Январь"
+
+[february]
+other = "Февраль"
+
+[march]
+other = "Март"
+
+[april]
+other = "Апрель"
+
+[may]
+other = "Март"
+
+[june]
+other = "Июнь"
+
+[july]
+other = "Июль"
+
+[august]
+other = "Август"
+
+[september]
+other = "Сентябрь"
+
+[october]
+other = "Октябрь"
+
+[november]
+other = "Ноябрь"
+
+[december]
+other = "Декабрь"
+
+
+# Numbers
+# Used for `i18nYear`
+
+[0]
+other = "0"
+
+[1]
+other = "1"
+
+[2]
+other = "2"
+
+[3]
+other = "3"
+
+[4]
+other = "4"
+
+[5]
+other = "5"
+
+[6]
+other = "6"
+
+[7]
+other = "7"
+
+[8]
+other = "8"
+
+[9]
+other = "9"
+

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -108,5 +108,10 @@
         {{ partial "third-party/google-adsense-auto.html" . }}
     {{- end }}
 
+    <!-- Yandex.Metrika -->
+    {{ if and .Site.Params.yandexMetrikaId (eq hugo.Environment "production") }}
+        {{ partial "third-party/yandex-metrika.html" . }}
+    {{- end }}
+
     {{ partial "custom/head.html" . }}
 </head>

--- a/layouts/partials/third-party/yandex-metrika.html
+++ b/layouts/partials/third-party/yandex-metrika.html
@@ -1,0 +1,16 @@
+{{ with .Site.Params.yandexMetrikaId }}
+    <!-- Yandex.Metrika counter -->
+    <script type="text/javascript" >
+        (function(m,e,t,r,i,k,a){m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+        m[i].l=1*new Date();k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+        (window, document, "script", "https://mc.yandex.ru/metrika/tag.js", "ym");
+
+        ym({{ . }}, "init", {
+            clickmap:true,
+            trackLinks:true,
+            accurateTrackBounce:true
+        });
+    </script>
+    <noscript><div><img src="https://mc.yandex.ru/watch/{{ . }}" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+    <!-- /Yandex.Metrika counter -->
+{{ end }}


### PR DESCRIPTION
[Yandex.Metrika](https://metrika.yandex.ru/) is a popular analytics tracking tool (similar to Google Analytics). The code in this PR adds support for the Yandex.Metrika by installing corresponding `<script>` code in the `<head>` section (and only in the production environment).

To configure the Yandex.Metrika counter, please specify `yandexMetrikaId` parameter with you y.metrika Id in your config.toml.