### PR TITLE
Exclude  medium-zoom for img tags directly under a tag

### DIFF
--- a/layouts/partials/third-party/medium-zoom.html
+++ b/layouts/partials/third-party/medium-zoom.html
@@ -1,7 +1,10 @@
 <script src="https://cdn.jsdelivr.net/npm/medium-zoom@latest/dist/medium-zoom.min.js"></script>
 
 <script>
-    mediumZoom(document.querySelectorAll('div.post-body img'), {
+    let imgNodes = document.querySelectorAll('div.post-body img');
+    imgNodes = Array.from(imgNodes).filter(node => node.parentNode.tagName !== "A");
+
+    mediumZoom(imgNodes, {
         background: 'hsla(var(--color-bg-h), var(--color-bg-s), var(--color-bg-l), 0.95)'
     })
 </script>


### PR DESCRIPTION
For example, I don't want to use medium-zoom when I write an img tag directly under the a tag in markdown, as shown below.


```md
<a href="https://gohugo.io/">
  <img src="https://cdn-ak.f.st-hatena.com/images/fotolife/r/rochefort/20210823/20210823225522_original.png" alt="Hugo" />
</a>
```