### PR TITLE
fix: make header width to 100vw to avoid change when scroll bar appears

### DIFF
--- a/assets/scss/layout/_header.scss
+++ b/assets/scss/layout/_header.scss
@@ -5,7 +5,7 @@
 @if ($headerLayoutFlex) {
     .header {
         position: fixed;
-        width: 100%;
+        width: 100vw;
     }
     .header-wrapper {
         padding: 1em 0;


### PR DESCRIPTION
change header width from 100% to 100vw in order to avoid difference resulted by scroll bar.
Resolves [#350](https://github.com/reuixiy/hugo-theme-meme/issues/350)