### PR TITLE
fix: drop cap to the identical paras only once

### DIFF
--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -52,7 +52,7 @@
     {{- $regexReplacementDropCap := `$1 style="text-indent:0"$2<span class="drop-cap">$3</span>$4` -}}
     {{- $firstParagraphOld := (delimit (findRE $regexPatternDropCap $Content 1) " ") -}}
     {{- $firstParagraphNew := (replaceRE $regexPatternDropCap $regexReplacementDropCap $firstParagraphOld) -}}
-    {{- $Content = replace $Content $firstParagraphOld $firstParagraphNew -}}
+    {{- $Content = replace $Content $firstParagraphOld $firstParagraphNew 1 -}}
 {{- end -}}
 
 <!-- Drop Cap After `<hr />` -->


### PR DESCRIPTION
```
// text
xxx
xxx
// before
Xxx
Xxx
// after
Xxx
xxx
```