### PR TITLE
fix: ignore suffix slash of image host

### DIFF
--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -113,14 +113,14 @@
 
 <!-- Image Hosting -->
 {{- if and .Site.Params.enableImageHost (eq hugo.Environment "production") -}}
-    {{- $hostURL := .Site.Params.imageHostURL -}}
+    {{- $hostURL := strings.TrimSuffix "/" .Site.Params.imageHostURL -}}
     {{- $temps := findRE `<(img) src="/?([^":]+)` $Content | uniq -}}
     {{- with $temps -}}
         {{- range . -}}
             {{- if not (in (slice "http" "ttps") (substr . -1 4)) -}}
                 {{- $url := replaceRE `<(img) src="/?([^":]+)` `$2` . -}}
                 {{- $prefix := replaceRE `(<(img) src=")/?([^":]+)` `$1` . -}}
-                {{- $replacement := (printf `%s%s%s` $prefix $hostURL $url) -}}
+                {{- $replacement := (printf `%s%s/%s` $prefix $hostURL $url) -}}
                 {{- $Content = replace $Content . $replacement -}}
             {{- end -}}
         {{- end -}}

--- a/layouts/partials/utils/images.html
+++ b/layouts/partials/utils/images.html
@@ -12,7 +12,7 @@
         {{- if and $.Site.Params.enableImageHost $.Site.Params.headAlso -}}
             {{- if (eq hugo.Environment "production") -}}
                 {{- if ne (substr . 0 4) "http" -}}
-                    {{- $img = printf `%s%s` $.Site.Params.imageHostURL (strings.TrimPrefix "/" $img) -}}
+                    {{- $img = printf `%s/%s` (strings.TrimSuffix "/" $.Site.Params.imageHostURL) (strings.TrimPrefix "/" $img) -}}
                 {{- end -}}
             {{- end -}}
         {{- end -}}


### PR DESCRIPTION
Enable both

```toml
imageHostURL = "https://example.com"
```

```toml
imageHostURL = "https://example.com/"
```
