### PR TITLE
fix(scss): solve issue #365

### DIFF
--- a/assets/scss/themes/_light.scss
+++ b/assets/scss/themes/_light.scss
@@ -15,6 +15,9 @@
     .theme-icon-dark {
         display: none;
     }
+    img {
+        filter: brightness(100%);
+    }
 
     @if ($enableHighlight) {
         /* https://xyproto.github.io/splash/docs/all.html */


### PR DESCRIPTION
when defaultTheme is dark, images won't change to 100% contrast when toggled to light mode (#365)