### PR TITLE
fix: check before loading comments

### DIFF
--- a/layouts/partials/third-party/disqus.html
+++ b/layouts/partials/third-party/disqus.html
@@ -1,6 +1,9 @@
 {{- $rawTitle := (partial "utils/title.html" (dict "$" . "title" .Title)).rawTitle -}}
 <script>
     function loadComments() {
+        if (!document.getElementById('disqus_thread')) {
+            return;
+        }
         if (typeof DISQUS === 'undefined') {
             var disqus_config = function() {
                 {{ with .Params.disqus_url | default .Permalink }}this.page.url = '{{ . }}';{{ end }}

--- a/layouts/partials/third-party/gitalk.html
+++ b/layouts/partials/third-party/gitalk.html
@@ -1,6 +1,9 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
 <script>
     function loadComments() {
+        if (!document.getElementById('gitalk-container')) {
+            return;
+        }
         if (typeof Gitalk === 'undefined') {
             var getScript = (options) => {
                 var script = document.createElement('script');

--- a/layouts/partials/third-party/utterances.html
+++ b/layouts/partials/third-party/utterances.html
@@ -2,6 +2,9 @@
     function loadComments() {
         (function() {
             var utterances = document.getElementById("utterances");
+            if (!utterances) {
+                return;
+            }
             var script = document.createElement('script');
             script.src = 'https://utteranc.es/client.js';
             script.async = true;

--- a/layouts/partials/third-party/valine.html
+++ b/layouts/partials/third-party/valine.html
@@ -1,5 +1,8 @@
 <script>
     function loadComments() {
+        if (!document.getElementById('vcomments')) {
+            return;
+        }
         if (typeof Valine === 'undefined') {
             var getScript = (options) => {
                 var script = document.createElement('script');


### PR DESCRIPTION
Check if the relevant container exists before loading comments to avoid uncaught errors being thrown when loading. For example, pages without comments will throw `Uncaught Error: Container not found, window.document.getElementById: gitalk-container` when using Gitalk.