### PR TITLE
Replace cdn.jsdelivr.net with fastly.jsdelivr.net

### DIFF
--- a/assets/js/copy.js
+++ b/assets/js/copy.js
@@ -67,7 +67,7 @@ window.addEventListener("DOMContentLoaded", event => {
         addCopyButtons(navigator.clipboard);
     } else {
         const script = document.createElement('script');
-        script.src = 'https://cdn.jsdelivr.net/npm/clipboard-polyfill@2.8.6/dist/clipboard-polyfill.min.js';
+        script.src = 'https://fastly.jsdelivr.net/npm/clipboard-polyfill@2.8.6/dist/clipboard-polyfill.min.js';
         script.defer = true;
         script.onload = function() {
             addCopyButtons(clipboard);

--- a/layouts/partials/third-party/algolia-search.html
+++ b/layouts/partials/third-party/algolia-search.html
@@ -1,4 +1,4 @@
-{{- $scripts := slice "https://cdn.jsdelivr.net/npm/instantsearch.js@2/dist/instantsearch.min.js" -}}
+{{- $scripts := slice "https://fastly.jsdelivr.net/npm/instantsearch.js@2/dist/instantsearch.min.js" -}}
 
 {{- $scripts = union $scripts (slice "js/algolia-search.js") -}}
 {{- return $scripts -}}

--- a/layouts/partials/third-party/gitalk.html
+++ b/layouts/partials/third-party/gitalk.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
+<link rel="stylesheet" href="https://fastly.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
 <script>
     function loadComments() {
         if (!document.getElementById('gitalk-container')) {
@@ -15,7 +15,7 @@
                 document.body.appendChild(script);
             };
             getScript({
-                src: 'https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js',
+                src: 'https://fastly.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js',
                 onload: () => {
                     newGitalk();
                 }

--- a/layouts/partials/third-party/instant-page.html
+++ b/layouts/partials/third-party/instant-page.html
@@ -1,1 +1,1 @@
-<script src="https://cdn.jsdelivr.net/npm/instant.page@5.1.0/instantpage.min.js" type="module" defer></script>
+<script src="https://fastly.jsdelivr.net/npm/instant.page@5.1.0/instantpage.min.js" type="module" defer></script>

--- a/layouts/partials/third-party/katex.html
+++ b/layouts/partials/third-party/katex.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.0/dist/katex.min.css" integrity="sha256-gPJfuwTULrEAAcI3X4bALVU/2qBU+QY/TpoD3GO+Exw=" crossorigin="anonymous">
+<link rel="stylesheet" href="https://fastly.jsdelivr.net/npm/katex@0.13.0/dist/katex.min.css" integrity="sha256-gPJfuwTULrEAAcI3X4bALVU/2qBU+QY/TpoD3GO+Exw=" crossorigin="anonymous">
 <script>
     if (typeof renderMathInElement === 'undefined') {
         var getScript = (options) => {
@@ -11,15 +11,15 @@
             document.body.appendChild(script);
         };
         getScript({
-            src: 'https://cdn.jsdelivr.net/npm/katex@0.13.0/dist/katex.min.js',
+            src: 'https://fastly.jsdelivr.net/npm/katex@0.13.0/dist/katex.min.js',
             integrity: 'sha256-YTW9cMncW/ZQMhY69KaUxIa2cPTxV87Uh627Gf5ODUw=',
             onload: () => {
                 getScript({
-                    src: 'https://cdn.jsdelivr.net/npm/katex@0.13.0/dist/contrib/mhchem.min.js',
+                    src: 'https://fastly.jsdelivr.net/npm/katex@0.13.0/dist/contrib/mhchem.min.js',
                     integrity: 'sha256-yzSfYeVsWJ1x+2g8CYHsB/Mn7PcSp8122k5BM4T3Vxw=',
                     onload: () => {
                         getScript({
-                            src: 'https://cdn.jsdelivr.net/npm/katex@0.13.0/dist/contrib/auto-render.min.js',
+                            src: 'https://fastly.jsdelivr.net/npm/katex@0.13.0/dist/contrib/auto-render.min.js',
                             integrity: 'sha256-fxJzNV6hpc8tgW8tF0zVobKa71eTCRGTgxFXt1ZpJNM=',
                             onload: () => {
                                 renderKaTex();

--- a/layouts/partials/third-party/lunr-search.html
+++ b/layouts/partials/third-party/lunr-search.html
@@ -1,12 +1,12 @@
-{{- $scripts := slice "https://cdn.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js" -}}
+{{- $scripts := slice "https://fastly.jsdelivr.net/npm/lunr@2.3.9/lunr.min.js" -}}
 {{- if ne .Site.Language.Lang "en" -}}
     {{- $supported := slice "ar" "da" "de" "du" "es" "fi" "fr" "hu" "it" "ja" "nl" "no" "pt" "ro" "ru" "sv" "tr" "vi" -}}
     {{- if in $supported .Site.Language.Lang -}}
         {{- if eq .Site.Language.Lang "ja" -}}
-            {{- $scripts = union $scripts (slice "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/tinyseg.js") -}}
+            {{- $scripts = union $scripts (slice "https://fastly.jsdelivr.net/npm/lunr-languages@1.4.0/tinyseg.js") -}}
         {{- end -}}
-        {{- $scripts = union $scripts (slice "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.stemmer.support.min.js") -}}
-        {{- $scripts = union $scripts (slice (printf "https://cdn.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.%s.min.js" .Site.Language.Lang)) -}}
+        {{- $scripts = union $scripts (slice "https://fastly.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.stemmer.support.min.js") -}}
+        {{- $scripts = union $scripts (slice (printf "https://fastly.jsdelivr.net/npm/lunr-languages@1.4.0/min/lunr.%s.min.js" .Site.Language.Lang)) -}}
     {{- else -}}
         {{- warnf "The site language %q isn't supported by lunr, the search results might be suboptimal. Supported languages are: %q" .Site.Language.Lang $supported -}}
     {{- end -}}

--- a/layouts/partials/third-party/mathjax.html
+++ b/layouts/partials/third-party/mathjax.html
@@ -19,7 +19,7 @@
         };
         (function() {
             var script = document.createElement('script');
-            script.src = 'https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-mml-chtml.js';
+            script.src = 'https://fastly.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-mml-chtml.js';
             script.defer = true;
             document.head.appendChild(script);
         })();

--- a/layouts/partials/third-party/medium-zoom.html
+++ b/layouts/partials/third-party/medium-zoom.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/medium-zoom@latest/dist/medium-zoom.min.js"></script>
+<script src="https://fastly.jsdelivr.net/npm/medium-zoom@latest/dist/medium-zoom.min.js"></script>
 
 <script>
     let imgNodes = document.querySelectorAll('div.post-body img');

--- a/layouts/partials/third-party/mermaid.html
+++ b/layouts/partials/third-party/mermaid.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/mermaid@8.8.3/dist/mermaid.min.js"></script>
+<script src="https://fastly.jsdelivr.net/npm/mermaid@8.8.3/dist/mermaid.min.js"></script>
 <script>
     let mermaidConfig = {
         startOnLoad: true,

--- a/layouts/partials/third-party/qrcode-generator.html
+++ b/layouts/partials/third-party/qrcode-generator.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
+<script src="https://fastly.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"></script>
 
 <script>
     var typeNumber = 0;

--- a/layouts/partials/third-party/valine.html
+++ b/layouts/partials/third-party/valine.html
@@ -14,7 +14,7 @@
                 document.body.appendChild(script);
             };
             getScript({
-                src: 'https://cdn.jsdelivr.net/npm/valine@1.4.14/dist/Valine.min.js',
+                src: 'https://fastly.jsdelivr.net/npm/valine@1.4.14/dist/Valine.min.js',
                 onload: () => {
                     newValine();
                 }


### PR DESCRIPTION
Due to cdn.jsdelivr.net has been DNS pollution in China,replace cdn.jsdelivr.net with fastly.jsdelivr.net