### PR TITLE
Remove country code on lunr language validation

### DIFF
--- a/layouts/partials/third-party/lunr-search.html
+++ b/layouts/partials/third-party/lunr-search.html
@@ -5,9 +5,10 @@
 
 {{- $scripts := slice $src -}}
 {{- if ne .Site.Language.Lang "en" -}}
+    {{- $lang := substr .Site.Language.Lang 0 2 -}}
     {{- $supported := slice "ar" "da" "de" "du" "es" "fi" "fr" "hu" "it" "ja" "nl" "no" "pt" "ro" "ru" "sv" "tr" "vi" -}}
-    {{- if in $supported .Site.Language.Lang -}}
-        {{- if eq .Site.Language.Lang "ja" -}}
+    {{- if in $supported $lang -}}
+        {{- if eq $lang "ja" -}}
             {{- $scripts = union $scripts (slice $srcTinyseg) -}}
         {{- end -}}
         {{- $scripts = union $scripts (slice $srcStemmer) -}}


### PR DESCRIPTION
While I was using this theme with the (pt-br)[https://github.com/reuixiy/hugo-theme-meme/blob/master/i18n/pt-br.toml] language, I noticed this warning:

```
WARN 2022/07/21 21:03:09 The site language "pt-br" isn't supported by lunr, the search results might be suboptimal. Supported languages are: ["ar" "da" "de" "du" "es" "fi" "fr" "hu" "it" "ja" "nl" "no" "pt" "ro" "ru" "sv" "tr" "vi"]
```

So I removed the country code (-br) from the validation and now the warning doesn't show anymore.