### PR TITLE
Add support for displaying TOC on the side of page

### DIFF
--- a/assets/scss/layout/_single.scss
+++ b/assets/scss/layout/_single.scss
@@ -102,7 +102,7 @@ blockquote {
 }
 
 .contents {
-    position: $tocPosition
+    position: $tocPosition;
     margin-top: 5em;
     ol, ul {
         list-style: none;

--- a/assets/scss/layout/_single.scss
+++ b/assets/scss/layout/_single.scss
@@ -102,6 +102,7 @@ blockquote {
 }
 
 .contents {
+    position: $tocPosition
     margin-top: 5em;
     ol, ul {
         list-style: none;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -410,6 +410,7 @@ $baseRelURL: "{{ strings.TrimSuffix (.Site.BaseURL | relURL) "/" }}";
     @import "pages/home-posts";
 {{ end }}
 
+
 // Categories Page
 
 {{ if .Site.Params.enableTree }}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -75,6 +75,12 @@
     $enableSmoothScroll: false;
 {{ end }}
 
+{{ if .Site.Params.displayTOConSide }}
+    $tocPosition: fixed;
+{{ else }}
+    $tocPosition: inherit;
+{{ end }}
+
 $baseRelURL: "{{ strings.TrimSuffix (.Site.BaseURL | relURL) "/" }}";
 
 
@@ -403,15 +409,6 @@ $baseRelURL: "{{ strings.TrimSuffix (.Site.BaseURL | relURL) "/" }}";
 {{ if eq .Site.Params.homeLayout "posts" }}
     @import "pages/home-posts";
 {{ end }}
-
-// Post
-
-{{ if .Site.Params.displayTOConEdge }}
-    $tocPosition: fixed;
-{{ else }}
-    $tocPosition: inherit;
-{{ end }}
-
 
 // Categories Page
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -404,6 +404,14 @@ $baseRelURL: "{{ strings.TrimSuffix (.Site.BaseURL | relURL) "/" }}";
     @import "pages/home-posts";
 {{ end }}
 
+// Post
+
+{{ if .Site.Params.displayTOConEdge }}
+    $tocPosition: fixed;
+{{ else }}
+    $tocPosition: inherit;
+{{ end }}
+
 
 // Categories Page
 

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -813,6 +813,9 @@ uglyURLs = false
     # 是否链接文章的分节标题到目录
     linkHeadingsToTOC = true
 
+    # 是否将目录置于页面左/右侧
+    displayTOConEdge = false
+
 
     ######################################
     # 分节标题锚点

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -813,8 +813,8 @@ uglyURLs = false
     # 是否链接文章的分节标题到目录
     linkHeadingsToTOC = true
 
-    # 是否将目录置于页面左/右侧
-    displayTOConEdge = false
+    # 是否将目录置于页面左侧
+    displayTOConSide = false
 
 
     ######################################

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -1,11 +1,12 @@
 <main class="main single" id="main">
-    <div class="main-inner">
 
-        {{ $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
-        {{ $displayTOConEdge := default .Site.Params.displayTOConEdge -}}
-        {{- if and $enableTOC $displayTOConEdge -}}
-        {{- partial "utils/toc.html" . -}}
-        {{- end -}}
+    {{ $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
+    {{ $displayTOConEdge := default .Site.Params.displayTOConEdge -}}
+    {{- if and $enableTOC $displayTOConEdge -}}
+    {{- partial "utils/toc.html" . -}}
+    {{- end -}}
+    
+    <div class="main-inner">
 
         {{ $attrs := partial "utils/data-attributes.html" . }}
 

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -1,8 +1,8 @@
 <main class="main single" id="main">
 
     {{ $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
-    {{ $displayTOConEdge := default .Site.Params.displayTOConEdge -}}
-    {{- if and $enableTOC $displayTOConEdge -}}
+    {{ $displayTOConSide := default .Site.Params.displayTOConSide -}}
+    {{- if and $enableTOC $displayTOConSide -}}
     {{- partial "utils/toc.html" . -}}
     {{- end -}}
     
@@ -37,7 +37,7 @@
             {{ end }}
 
             {{- if $enableTOC -}}
-                {{- if not $displayTOConEdge -}}
+                {{- if not $displayTOConSide -}}
                     {{- partial "utils/toc.html" . -}}
                 {{- end -}}
             {{- end -}}

--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -1,6 +1,12 @@
 <main class="main single" id="main">
     <div class="main-inner">
 
+        {{ $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
+        {{ $displayTOConEdge := default .Site.Params.displayTOConEdge -}}
+        {{- if and $enableTOC $displayTOConEdge -}}
+        {{- partial "utils/toc.html" . -}}
+        {{- end -}}
+
         {{ $attrs := partial "utils/data-attributes.html" . }}
 
         <article class="content post h-entry"
@@ -29,9 +35,10 @@
                 {{ partial "components/post-meta.html" (dict "$" . "isHome" false) }}
             {{ end }}
 
-            {{ $enableTOC := .Params.toc | default .Site.Params.enableTOC -}}
             {{- if $enableTOC -}}
-                {{- partial "utils/toc.html" . -}}
+                {{- if not $displayTOConEdge -}}
+                    {{- partial "utils/toc.html" . -}}
+                {{- end -}}
             {{- end -}}
 
             <div class="post-body e-content">


### PR DESCRIPTION
Due to #64, #368 and #387, many users want to display TOC on the side of their pages. I add a variable called `displayTOConSide`. If it's set to `false`(by default), the TOC will be displayed on the top of the article; If it's set to `true`, the TOC will be displayed on the side of the article.

The `position` of TOC will be set to `fixed` if `displayTOConSide` is true. Users can DIY their style of TOC(such as on the left or right) by modifing `contents`  in [_single.scss](https://github.com/reuixiy/hugo-theme-meme/blob/master/assets/scss/layout/_single.scss).