### PR TITLE
Add gallery mode

### DIFF
--- a/layouts/partials/pages/post.html
+++ b/layouts/partials/pages/post.html
@@ -35,7 +35,11 @@
             {{- end -}}
 
             <div class="post-body e-content">
-                {{ partial "utils/content.html" . }}
+                {{if .Params.gallery }}
+                    {{ partial "utils/gallery.html" . }}
+                {{ else }}
+                    {{ partial "utils/content.html" . }}
+                {{ end }}
             </div>
 
             {{ partial "components/post-copyright.html" . }}

--- a/layouts/partials/third-party/script.html
+++ b/layouts/partials/third-party/script.html
@@ -32,7 +32,8 @@
     {{ end }}
 {{ end }}
 
-{{ if .Site.Params.enableMediumZoom }}
+
+{{ if and (.Site.Params.enableMediumZoom) (not .Params.gallery) }}
     {{ partial "third-party/medium-zoom.html" . }}
 {{ end }}
 

--- a/layouts/partials/utils/gallery.html
+++ b/layouts/partials/utils/gallery.html
@@ -1,0 +1,57 @@
+{{- $Content := partial "utils/markdownify.html" (dict "$" . "raw" .Content "isContent" true) -}}
+<!-- https://github.com/blueimp/Gallery -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/blueimp-gallery@3.3.0/css/blueimp-gallery.min.css">
+{{- if and (.Params.gallery) -}}
+    <div id="blueimp-gallery" class="blueimp-gallery blueimp-gallery-controls" aria-label="image gallery"
+    aria-modal="true" role="dialog">
+        <div class="slides" aria-live="polite"></div>
+        <h3 class="title"></h3>
+        <a class="prev" aria-controls="blueimp-gallery" aria-label="previous slide" aria-keyshortcuts="ArrowLeft"></a>
+        <a class="next" aria-controls="blueimp-gallery" aria-label="next slide" aria-keyshortcuts="ArrowRight"></a>
+        <a class="close" aria-controls="blueimp-gallery" aria-label="close" aria-keyshortcuts="Escape"></a>
+        <a class="play-pause" aria-controls="blueimp-gallery" aria-label="play slideshow" aria-keyshortcuts="Space"
+            aria-pressed="false" role="button"></a>
+        <ol class="indicator"></ol>
+    </div>
+    <div id="links">
+        {{- $regexGallery := `<img src="(.+?)" alt="(.*?)">` -}}
+        {{- $regexReplacementGallery := `<a href="$1" title="$2"><img src="$1" alt="$2"></a>` -}}
+        {{- $Content = $Content | replaceRE $regexGallery $regexReplacementGallery -}}
+        {{ $Content | safeHTML }}
+    </div>
+{{- end -}}
+
+<script src="https://cdn.jsdelivr.net/npm/blueimp-gallery@3.3.0/js/blueimp-gallery.min.js"></script>
+<script>
+    document.getElementById('links').onclick = function (event) {
+        event = event || window.event
+        var target = event.target || event.srcElement
+        var link = target.src ? target.parentNode : target
+        var options = {
+            index: link, event: event, onslide: function (index, slide) {
+                var text = this.list[index].getAttribute('data-description'),
+                    node = this.container.find('.description')
+                node.empty()
+                if (text) {
+                    node[0].appendChild(document.createTextNode(text))
+                }
+            }
+        }
+        var links = this.getElementsByTagName('a')
+        blueimp.Gallery(links, options)
+    }
+</script>
+<style>
+    .blueimp-gallery > .description {
+        position: relative;
+        /* top: 30px; */
+        /* left: 15px; */
+        margin-top: 15px;
+        color: #fff;
+        display: none;
+    }
+
+    .blueimp-gallery-controls>.description {
+        display: block;
+    }
+</style>


### PR DESCRIPTION
Add gallery mode for posts which only show collection of images.

Just add `gallery: true` into FrontMatter.

Example: [https://rxrw.me/travel/记录个中秋/](https://rxrw.me/travel/%E8%AE%B0%E5%BD%95%E4%B8%AA%E4%B8%AD%E7%A7%8B/)