### PR TITLE
fix: image and video host

### DIFF
--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -117,8 +117,8 @@
     {{- $temps := findRE `<(img) src="/?([^":]+)` $Content | uniq -}}
     {{- with $temps -}}
         {{- range . -}}
-            {{- if not (in (slice "http" "ttps") (substr . -1 4)) -}}
-                {{- $url := replaceRE `<(img) src="/?([^":]+)` `$2` . -}}
+            {{- $url := replaceRE `<(img) src="/?([^":]+)` `$2` . -}}
+            {{- if ne (substr $url 0 4) "http" -}}
                 {{- $prefix := replaceRE `(<(img) src=")/?([^":]+)` `$1` . -}}
                 {{- $replacement := (printf `%s%s/%s` $prefix $hostURL $url) -}}
                 {{- $Content = replace $Content . $replacement -}}
@@ -133,8 +133,8 @@
     {{- $temps := findRE `<(video) src="/?([^":]+)` $Content | uniq -}}
     {{- with $temps -}}
         {{- range . -}}
-            {{- if not (in (slice "http" "ttps") (substr . -1 4)) -}}
-                {{- $url := replaceRE `<(video) src="/?([^":]+)` `$2` . -}}
+            {{- $url := replaceRE `<(video) src="/?([^":]+)` `$2` . -}}
+            {{- if ne (substr $url 0 4) "http" -}}
                 {{- $prefix := replaceRE `(<(video) src=")/?([^":]+)` `$1` . -}}
                 {{- $replacement := (printf `%s%s/%s` $prefix $hostURL $url) -}}
                 {{- $Content = replace $Content . $replacement -}}


### PR DESCRIPTION
I try to write the following markdown:

```markdown
![](https://path.to.img)
```

And find that the image url was replaced with `imageHostURL/https://path.to.img`.
