### PR TITLE
Improve google adsense for units display

### DIFF
--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -772,6 +772,8 @@ uglyURLs = false
     ## Ad Units
     enableGoogleAdUnits = false
     googleAdSlot = ""
+    googleAdSlotInArticle = ""
+    googleAdSlotAutoRelaxed = ""
 
 
     ######################################

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -717,6 +717,8 @@ uglyURLs = false
     ## 广告单元
     enableGoogleAdUnits = false
     googleAdSlot = ""
+    googleAdSlotInArticle = ""
+    googleAdSlotAutoRelaxed = ""
 
 
     ######################################

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -717,6 +717,8 @@ uglyURLs = false
     ## 廣告單元
     enableGoogleAdUnits = false
     googleAdSlot = ""
+    googleAdSlotInArticle = ""
+    googleAdSlotAutoRelaxed = ""
 
 
     ######################################

--- a/layouts/partials/third-party/google-adsense-unit.html
+++ b/layouts/partials/third-party/google-adsense-unit.html
@@ -1,6 +1,26 @@
-<ins class="adsbygoogle" style="display:block; text-align:center;"
+{{ if .Site.Params.googleAdSlot -}}
+<ins class="adsbygoogle"
+    style="display: block"
     data-ad-client="{{ .Site.Params.googleAdClient }}"
-    data-ad-slot="{{ .Site.Params.googleAdSlot }}"></ins>
+    data-ad-slot="{{ .Site.Params.googleAdSlot }}"
+    data-ad-format="auto"
+    data-full-width-responsive="true"></ins>
+{{- end }}
+{{ if .Site.Params.googleAdSlotInArticle -}}
+<ins class="adsbygoogle"
+    style="display: block; text-align: center"
+    data-ad-layout="in-article"
+    data-ad-format="fluid"
+    data-ad-client="{{ .Site.Params.googleAdClient }}"
+    data-ad-slot="{{ .Site.Params.googleAdSlotInArticle }}"></ins>
+{{- end }}
+{{ if .Site.Params.googleAdSlotAutoRelaxed -}}
+<ins class="adsbygoogle"
+    style="display:block"
+    data-ad-format="autorelaxed"
+    data-ad-client="{{ .Site.Params.googleAdClient }}"
+    data-ad-slot="{{ .Site.Params.googleAdSlotAutoRelaxed }}"></ins>
+{{- end }}
 <script>
     (adsbygoogle = window.adsbygoogle || []).push({});
 </script>


### PR DESCRIPTION
Currently Google Adsense Unit Ads support many kinds of ads. I adjust the partial file to support as most 3 kinds of ads including autofit(same as before), in article and auto relaxed.

Maybe it's too many ads in my blog enough..