### PR TITLE
feat: Allow setting the order of share items via postShareItems option (fixes #446)

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -325,13 +325,13 @@ $baseRelURL: "{{ "" | relURL | strings.TrimSuffix "/" }}";
         $displayShareOnText: false;
     {{ end }}
 
-    {{ if or .Site.Params.shareOnMastodon .Site.Params.shareOnFediverse }}
+    {{ if or (in .Site.Params.postShareItems "mastodon") (in .Site.Params.postShareItems "fediverse") }}
         $shareOnFediverse: true;
     {{ else }}
         $shareOnFediverse: false;
     {{ end }}
 
-    {{ if and .Site.Params.shareViaQRCode }}
+    {{ if in .Site.Params.postShareItems "qrcode" }}
         $shareViaQRCode: true;
     {{ else }}
         $shareViaQRCode: false;

--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -1204,7 +1204,7 @@ uglyURLs = false
 
     # Fetch fediverse instances list for
     # input suggestions
-    fetchFediverseInstances = true
+    shareFetchFediverseInstances = true
     # Note: Recommended when using mastodon
     #       or fediverse share items. This will
     #       cause a list of instances to be

--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -1204,7 +1204,7 @@ uglyURLs = false
 
     # Fetch fediverse instances list for
     # input suggestions
-    shareFetchFediverseInstances = true
+    fetchFediverseInstances = true
     # Note: Recommended when using mastodon
     #       or fediverse share items. This will
     #       cause a list of instances to be

--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -1200,24 +1200,13 @@ uglyURLs = false
 
     displayShareOnText = false
 
-    shareOnTwitter = true
-    shareOnFacebook = true
-    shareOnMastodon = true
-    shareOnFediverse = true
-    shareOnLinkedIn = true
-    shareOnTelegram = true
-    shareOnWeibo = true
-    shareOnDouban = true
-    shareOnQQ = true
-    shareOnQzone = true
-
-    shareViaQRCode = true
+    postShareItems = ["facebook", "mastodon", "fediverse", "twitter", "linkedin", "telegram", "weibo", "douban", "qq", "qzone", "qrcode"]
 
     # Fetch fediverse instances list for
     # input suggestions
     shareFetchFediverseInstances = true
-    # Note: Recommended when using shareOnMastodon
-    #       or shareOnFediverse. This will
+    # Note: Recommended when using mastodon
+    #       or fediverse share items. This will
     #       cause a list of instances to be
     #       downloaded at build time. There
     #       might be build delays.

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -1155,18 +1155,7 @@ uglyURLs = false
 
     displayShareOnText = false
 
-    shareOnTwitter = true
-    shareOnFacebook = true
-    shareOnMastodon = true
-    shareOnFediverse = true
-    shareOnLinkedIn = true
-    shareOnTelegram = true
-    shareOnWeibo = true
-    shareOnDouban = true
-    shareOnQQ = true
-    shareOnQzone = true
-
-    shareViaQRCode = true
+    postShareItems = ["facebook", "mastodon", "fediverse", "twitter", "linkedin", "telegram", "weibo", "douban", "qq", "qzone", "qrcode"]
 
     # 从网络获取 Fediverse 实例列表用于输入建议
     shareFetchFediverseInstances = true

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -1158,7 +1158,7 @@ uglyURLs = false
     postShareItems = ["facebook", "mastodon", "fediverse", "twitter", "linkedin", "telegram", "weibo", "douban", "qq", "qzone", "qrcode"]
 
     # 从网络获取 Fediverse 实例列表用于输入建议
-    fetchFediverseInstances = true
+    shareFetchFediverseInstances = true
     # 说明：当开启 mastodon 或 fediverse 分享项
     #      时建议开启。开启后构建时，数据需要从网
     #      络下载，会带来额外的构建时间。

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -1158,7 +1158,7 @@ uglyURLs = false
     postShareItems = ["facebook", "mastodon", "fediverse", "twitter", "linkedin", "telegram", "weibo", "douban", "qq", "qzone", "qrcode"]
 
     # 从网络获取 Fediverse 实例列表用于输入建议
-    shareFetchFediverseInstances = true
+    fetchFediverseInstances = true
     # 说明：当开启 mastodon 或 fediverse 分享项
     #      时建议开启。开启后构建时，数据需要从网
     #      络下载，会带来额外的构建时间。

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -1159,10 +1159,9 @@ uglyURLs = false
 
     # 从网络获取 Fediverse 实例列表用于输入建议
     shareFetchFediverseInstances = true
-    # 说明：当使用 shareOnMastodon 或
-    #      shareOnFediverse 时建议开启。开启后
-    #      构建时，数据需要从网络下载，会带来额外
-    #      的构建时间。
+    # 说明：当开启 mastodon 或 fediverse 分享项
+    #      时建议开启。开启后构建时，数据需要从网
+    #      络下载，会带来额外的构建时间。
 
 
     ######################################

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -1158,7 +1158,7 @@ uglyURLs = false
     postShareItems = ["facebook", "mastodon", "fediverse", "twitter", "linkedin", "telegram", "weibo", "douban", "qq", "qzone", "qrcode"]
 
     # 從網路取得 Fediverse 實例清單用於輸入建議
-    shareFetchFediverseInstances = true
+    fetchFediverseInstances = true
     # 說明：當開啟 mastodon 或 fediverse 分享項
     #      時建議開啟。開啟後建置時，資料需要從網
     #      路下載，會帶來額外的建置時間。

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -1155,18 +1155,7 @@ uglyURLs = false
 
     displayShareOnText = false
 
-    shareOnTwitter = true
-    shareOnFacebook = true
-    shareOnMastodon = true
-    shareOnFediverse = true
-    shareOnLinkedIn = true
-    shareOnTelegram = true
-    shareOnWeibo = true
-    shareOnDouban = true
-    shareOnQQ = true
-    shareOnQzone = true
-
-    shareViaQRCode = true
+    postShareItems = ["facebook", "mastodon", "fediverse", "twitter", "linkedin", "telegram", "weibo", "douban", "qq", "qzone", "qrcode"]
 
     # 從網路取得 Fediverse 實例清單用於輸入建議
     shareFetchFediverseInstances = true

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -1159,10 +1159,9 @@ uglyURLs = false
 
     # 從網路取得 Fediverse 實例清單用於輸入建議
     shareFetchFediverseInstances = true
-    # 說明：當使用 shareOnMastodon 或
-    #      shareOnFediverse 時建議開啟。開啟後
-    #      建置時，資料需要從網路下載，會帶來額外
-    #      的建置時間。
+    # 說明：當開啟 mastodon 或 fediverse 分享項
+    #      時建議開啟。開啟後建置時，資料需要從網
+    #      路下載，會帶來額外的建置時間。
 
 
     ######################################

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -1158,7 +1158,7 @@ uglyURLs = false
     postShareItems = ["facebook", "mastodon", "fediverse", "twitter", "linkedin", "telegram", "weibo", "douban", "qq", "qzone", "qrcode"]
 
     # 從網路取得 Fediverse 實例清單用於輸入建議
-    fetchFediverseInstances = true
+    shareFetchFediverseInstances = true
     # 說明：當開啟 mastodon 或 fediverse 分享項
     #      時建議開啟。開啟後建置時，資料需要從網
     #      路下載，會帶來額外的建置時間。

--- a/layouts/partials/components/fedishare.html
+++ b/layouts/partials/components/fedishare.html
@@ -34,7 +34,7 @@
                 (dict "domain" "bookwyrm.social" "softwarename" "bookwyrm" "score" "100" "active_users_monthly" "1000")
                 (dict "domain" "diasp.org" "softwarename" "diaspora" "score" "100" "active_users_monthly" "1000")
         -}}
-        {{ if .Site.Params.shareFetchFediverseInstances -}}
+        {{ if .Site.Params.fetchFediverseInstances -}}
             {{ with resources.GetRemote "https://api.fediverse.observer/"  (dict
                 "method" "post"
                 "body" `query={nodes(softwarename: ""){softwarename domain score active_users_monthly}}`

--- a/layouts/partials/components/fedishare.html
+++ b/layouts/partials/components/fedishare.html
@@ -34,7 +34,7 @@
                 (dict "domain" "bookwyrm.social" "softwarename" "bookwyrm" "score" "100" "active_users_monthly" "1000")
                 (dict "domain" "diasp.org" "softwarename" "diaspora" "score" "100" "active_users_monthly" "1000")
         -}}
-        {{ if .Site.Params.fetchFediverseInstances -}}
+        {{ if .Site.Params.shareFetchFediverseInstances -}}
             {{ with resources.GetRemote "https://api.fediverse.observer/"  (dict
                 "method" "post"
                 "body" `query={nodes(softwarename: ""){softwarename domain score active_users_monthly}}`

--- a/layouts/partials/components/post-share.html
+++ b/layouts/partials/components/post-share.html
@@ -31,112 +31,97 @@
 
         <div class="share-items">
 
-            {{ if .Site.Params.shareOnTwitter }}
-                <div class="share-item twitter">
-                    {{ $url := (printf `https://twitter.com/share?url=%s&text=%s&hashtags=%s&via=%s` .Permalink $title ($hashtags.Get "tags" | default "") .Site.Params.siteTwitter) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "twitter" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "twitter" "class" "twitter-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if .Site.Params.shareOnFacebook }}
-                <div class="share-item facebook">
-                    {{ $url := (printf `https://www.facebook.com/sharer/sharer.php?u=%s&hashtag=%s` .Permalink ($hashtags.Get "firsttag" | default "")) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "facebook" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "facebook" "class" "facebook-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if or .Site.Params.shareOnMastodon .Site.Params.shareOnFediverse }}
-                {{ $path := (strings.TrimPrefix "/" (printf `%s/fedishare.html` .Site.LanguagePrefix)) -}}
-                {{ $page := resources.Get "html/fedishare.html" -}}
-                {{ $page := $page | resources.ExecuteAsTemplate $path (.GetPage "/") -}}
-                {{ if .Site.Params.enableFingerprint -}}
-                    {{ $page = $page | resources.Fingerprint -}}
-                {{ end -}}
-                {{ $url := printf "%s#title=%s&description=%s&url=%s" $page.RelPermalink ($title | safeURL) ($description | safeURL) (.Permalink | safeURL) -}}
-                {{ if .Site.Params.shareOnMastodon -}}
-                    <div class="share-item mastodon">
-                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "mastodon" }}" target="_blank" rel="noopener">
-                            {{- partial "utils/icon.html" (dict "$" . "name" "mastodon" "class" "mastodon-icon") -}}
+            {{ $ := . }}
+            {{ range .Site.Params.postShareItems | default (slice "facebook" "mastodon" "fediverse" "twitter") }}
+                {{ if eq . "twitter" }}
+                    <div class="share-item twitter">
+                        {{ $url := (printf `https://twitter.com/share?url=%s&text=%s&hashtags=%s&via=%s` $.Permalink $title ($hashtags.Get "tags" | default "") $.Site.Params.siteTwitter) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "twitter" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "twitter" "class" "twitter-icon") -}}
                         </a>
                     </div>
-                {{ end -}}
-                {{ if .Site.Params.shareOnFediverse -}}
-                    <div class="share-item fediverse">
-                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "fediverse" }}" target="_blank" rel="noopener">
-                            {{- partial "utils/icon.html" (dict "$" . "name" "fediverse" "class" "fediverse-icon") -}}
+                {{ else if eq . "facebook" }}
+                    <div class="share-item facebook">
+                        {{ $url := (printf `https://www.facebook.com/sharer/sharer.php?u=%s&hashtag=%s` $.Permalink ($hashtags.Get "firsttag" | default "")) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "facebook" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "facebook" "class" "facebook-icon") -}}
                         </a>
                     </div>
-                {{ end -}}
-            {{ end }}
-
-            {{ if .Site.Params.shareOnLinkedIn }}
-                <div class="share-item linkedin">
-                    {{ $url := (printf `https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s&summary=%s&source=%s` .Permalink $title $description .Site.Title) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "linkedin" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "linkedin" "class" "linkedin-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if .Site.Params.shareOnTelegram }}
-                <div class="share-item telegram">
-                    {{ $url := (printf `https://t.me/share/url?url=%s&text=%s` .Permalink $title) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "telegram" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "telegram" "class" "telegram-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if .Site.Params.shareOnWeibo }}
-                <div class="share-item weibo">
-                    {{ $url := (printf `https://service.weibo.com/share/share.php?&url=%s&title=%s&pic=%s&searchPic=false` .Permalink $title $images) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "weibo" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "weibo" "class" "weibo-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if .Site.Params.shareOnDouban }}
-                <div class="share-item douban">
-                    {{ $url := (printf `https://www.douban.com/share/service?href=%s&name=%s&text=%s` .Permalink $title $description) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "douban" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "douban" "class" "douban-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if .Site.Params.shareOnQQ }}
-                <div class="share-item qq">
-                    {{ $url := (printf `https://connect.qq.com/widget/shareqq/index.html?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink $title $description $images .Site.Title) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qq" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "qq" "class" "qq-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if .Site.Params.shareOnQzone }}
-                <div class="share-item qzone">
-                    {{ $url := (printf `https://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=%s&title=%s&summary=%s&pics=%s&site=%s` .Permalink $title $description $images .Site.Title) }}
-                    <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qzone" }}" target="_blank" rel="noopener">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "qzone" "class" "qzone-icon") -}}
-                    </a>
-                </div>
-            {{ end }}
-
-            {{ if .Site.Params.shareViaQRCode }}
-                <div class="share-item qrcode">
-                    <div class="qrcode-container" title="{{ i18n "shareViaTitle" }}{{ i18n "qrcode" }}">
-                        {{- partial "utils/icon.html" (dict "$" . "name" "qrcode" "class" "qrcode-icon") -}}
-                        <div id="qrcode-img"></div>
+                {{ else if or (eq . "mastodon") (eq . "fediverse") }}
+                    {{ $path := (strings.TrimPrefix "/" (printf `%s/fedishare.html` $.Site.LanguagePrefix)) -}}
+                    {{ $page := resources.Get "html/fedishare.html" -}}
+                    {{ $page := $page | resources.ExecuteAsTemplate $path ($.GetPage "/") -}}
+                    {{ if $.Site.Params.enableFingerprint -}}
+                        {{ $page = $page | resources.Fingerprint -}}
+                    {{ end -}}
+                    {{ $url := printf "%s#title=%s&description=%s&url=%s" $page.RelPermalink ($title | safeURL) ($description | safeURL) ($.Permalink | safeURL) -}}
+                    {{ if eq . "mastodon" -}}
+                        <div class="share-item mastodon">
+                            <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "mastodon" }}" target="_blank" rel="noopener">
+                                {{- partial "utils/icon.html" (dict "$" $ "name" "mastodon" "class" "mastodon-icon") -}}
+                            </a>
+                        </div>
+                    {{ else if eq . "fediverse" -}}
+                        <div class="share-item fediverse">
+                            <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "fediverse" }}" target="_blank" rel="noopener">
+                                {{- partial "utils/icon.html" (dict "$" $ "name" "fediverse" "class" "fediverse-icon") -}}
+                            </a>
+                        </div>
+                    {{ end -}}
+                {{ else if eq . "linkedin" }}
+                    <div class="share-item linkedin">
+                        {{ $url := (printf `https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s&summary=%s&source=%s` $.Permalink $title $description $.Site.Title) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "linkedin" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "linkedin" "class" "linkedin-icon") -}}
+                        </a>
                     </div>
-                    {{ partial "third-party/qrcode-generator.html" . }}
-                </div>
+                {{ else if eq  . "telegram" }}
+                    <div class="share-item telegram">
+                        {{ $url := (printf `https://t.me/share/url?url=%s&text=%s` $.Permalink $title) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "telegram" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "telegram" "class" "telegram-icon") -}}
+                        </a>
+                    </div>
+                {{ else if eq . "weibo" }}
+                    <div class="share-item weibo">
+                        {{ $url := (printf `https://service.weibo.com/share/share.php?&url=%s&title=%s&pic=%s&searchPic=false` $.Permalink $title $images) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "weibo" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "weibo" "class" "weibo-icon") -}}
+                        </a>
+                    </div>
+                {{ else if eq . "douban" }}
+                    <div class="share-item douban">
+                        {{ $url := (printf `https://www.douban.com/share/service?href=%s&name=%s&text=%s` $.Permalink $title $description) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "douban" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "douban" "class" "douban-icon") -}}
+                        </a>
+                    </div>
+                {{ else if eq . "qq" }}
+                    <div class="share-item qq">
+                        {{ $url := (printf `https://connect.qq.com/widget/shareqq/index.html?url=%s&title=%s&summary=%s&pics=%s&site=%s` $.Permalink $title $description $images $.Site.Title) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qq" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "qq" "class" "qq-icon") -}}
+                        </a>
+                    </div>
+                {{ else if eq . "qzone" }}
+                    <div class="share-item qzone">
+                        {{ $url := (printf `https://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=%s&title=%s&summary=%s&pics=%s&site=%s` $.Permalink $title $description $images $.Site.Title) }}
+                        <a href="{{ $url }}" title="{{ i18n "shareOnTitle" }}{{ i18n "qzone" }}" target="_blank" rel="noopener">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "qzone" "class" "qzone-icon") -}}
+                        </a>
+                    </div>
+                {{ else if eq . "qrcode" }}
+                    <div class="share-item qrcode">
+                        <div class="qrcode-container" title="{{ i18n "shareViaTitle" }}{{ i18n "qrcode" }}">
+                            {{- partial "utils/icon.html" (dict "$" $ "name" "qrcode" "class" "qrcode-icon") -}}
+                            <div id="qrcode-img"></div>
+                        </div>
+                        {{ partial "third-party/qrcode-generator.html" $ }}
+                    </div>
+                {{ else }}
+                    {{ warnf "postShareItems option contains unknown share item '%s'" . }}
+                {{ end }}
             {{ end }}
-
         </div>
 
     </div>


### PR DESCRIPTION
BREAKING CHANGE: options like shareOnFacebook or shareViaQRCode have been replaced by postShareItems option