### PR TITLE
feat: Support fediverse:creator OpenGraph tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,11 @@ See [#2](https://github.com/reuixiy/hugo-theme-meme/issues/2).
   | motto                                       | author’s description                                                                                     | string                                                                       |
   | avatar                                      | author’s avatar                                                                                          | string, URL                                                                  |
   | twitter                                     | author’s twitter id                                                                                      | string                                                                       |
+  | fediverse                                   | author’s fediverse id                                                                                    | string                                                                       |
   | disqus_url                                  | \*                                                                                                       | string, if not set, will use `Permalink` as default                          |
   | disqus_identifier                           | \*                                                                                                       | string, if not set, will use `RelPermalink` as default                       |
   | disqus_title                                | \*                                                                                                       | string, if not set, will use `Title` as default                              |
 
-  \*: see https://gohugo.io/content-management/front-matter/  
+  \*: see https://gohugo.io/content-management/front-matter/
       and https://gohugo.io/templates/internal/#configure-disqus
 </details>

--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -1523,3 +1523,5 @@ uglyURLs = false
         website = "https://io-oi.me/"
         # Twitter
         twitter = "reuixiy"
+        # Fediverse
+        fediverse = "@reuixiy@bird.makeup"

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -1488,3 +1488,5 @@ uglyURLs = false
         website = "https://io-oi.me/"
         # 推特
         twitter = "reuixiy"
+        # Fediverse
+        fediverse = "@reuixiy@bird.makeup"

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -1488,3 +1488,5 @@ uglyURLs = false
         website = "https://io-oi.me/"
         # 推特
         twitter = "reuixiy"
+        # Fediverse
+        fediverse = "@reuixiy@bird.makeup"

--- a/layouts/partials/utils/author.html
+++ b/layouts/partials/utils/author.html
@@ -22,6 +22,9 @@
     {{- with .Site.Params.author.twitter -}}
         {{- $author = merge $author (dict "twitter" .) -}}
     {{- end -}}
+    {{- with .Site.Params.author.fediverse -}}
+        {{- $author = merge $author (dict "fediverse" .) -}}
+    {{- end -}}
 {{- else -}}
     {{- with .Params.author -}}
         {{- $author = merge $author (dict "name" .) -}}
@@ -43,6 +46,9 @@
     {{- end -}}
     {{- with .Params.twitter -}}
         {{- $author = merge $author (dict "twitter" .) -}}
+    {{- end -}}
+    {{- with .Params.fediverse -}}
+        {{- $author = merge $author (dict "fediverse" .) -}}
     {{- end -}}
 {{- end -}}
 {{- return $author -}}

--- a/layouts/partials/utils/open-graph.html
+++ b/layouts/partials/utils/open-graph.html
@@ -7,6 +7,8 @@
 {{- $description := .description -}}
 <!-- Date -->
 {{- $dates := partial "utils/date.html" $ -}}
+<!-- Author -->
+{{- $author := partial "utils/author.html" $ -}}
 <!-- Images -->
 {{- $images := partial "utils/images.html" $ -}}
 
@@ -41,4 +43,7 @@
     <meta property="article:section" content="{{ $.Section }}" />
 {{ else -}}
     <meta property="og:type" content="website" />
+{{- end }}
+{{- with $author.fediverse -}}
+    <meta name="fediverse:creator" content="{{ . }}" />
 {{- end }}


### PR DESCRIPTION
See https://rknight.me/blog/highlighting-journalism-with-the-fediverse-creator-tag/ on information about the Fediverse Creator tag. It’s pretty new, Mastodon (and likely other applications as well soon) now supports linking to the Fediverse user who authored the article.