### PR TITLE
fix removed variables

### DIFF
--- a/layouts/partials/components/post-nav.html
+++ b/layouts/partials/components/post-nav.html
@@ -3,8 +3,8 @@
         {{ .Scratch.Set "prev" .PrevInSection }}
         {{ .Scratch.Set "next" .NextInSection }}
     {{ else }}
-        {{ .Scratch.Set "prev" .PrevPage }}
-        {{ .Scratch.Set "next" .NextPage }}
+        {{ .Scratch.Set "prev" .Prev }}
+        {{ .Scratch.Set "next" .Next }}
     {{ end }}
     {{ $prev := .Scratch.Get "prev" }}
     {{ $next := .Scratch.Get "next" }}


### PR DESCRIPTION
@reuixiy  `.Page.PrevPage` and `.Page.NextPage` were deprecated in Hugo v0.123.0 and have been removed in Hugo 0.141.0.
Use .Page.Prev instead.