### PR TITLE
Feat: add aria-label for back-to-top link

### DIFF
--- a/i18n/de.toml
+++ b/i18n/de.toml
@@ -63,6 +63,9 @@ other = "{{ .Count }} Suchergebnisse für „{{ .Term }}” gefunden"
 [searchResultsNone]
 other = "Leider keine Suchergebnisse für „{{ .Term }}”"
 
+[backToTop]
+other = "Zurück nach oben"
+
 [themeSwitcher]
 other = "Thema wechseln"
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -63,6 +63,9 @@ other = "Found {{ .Count }} results for “{{ .Term }}”"
 [searchResultsNone]
 other = "No results found for “{{ .Term }}”"
 
+[backToTop]
+other = "Back to top"
+
 [themeSwitcher]
 other = "Switch theme"
 

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -63,6 +63,9 @@ other = "Se encontraron {{ .Count }} resultados sobre “{{ .Term }}”"
 [searchResultsNone]
 other = "No se encontró ningún resultado sobre “{{ .Term }}”"
 
+[backToTop]
+other = "Volver arriba"
+
 [themeSwitcher]
 other = "Cambiar tema"
 

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -63,6 +63,9 @@ other = "Trouvé {{ .Count }} résultats pour “{{ .Term }}”"
 [searchResultsNone]
 other = "Aucun résultat pour “{{ .Term }}”"
 
+[backToTop]
+other = "Retour en haut"
+
 [themeSwitcher]
 other = "Changer de thème"
 

--- a/i18n/hu.toml
+++ b/i18n/hu.toml
@@ -63,6 +63,9 @@ other = "A “{{ .Term }}” kifejezésre {{ .Count }} eredményt találtam"
 [searchResultsNone]
 other = "A “{{ .Term }}” kifejezésre nincs találat"
 
+[backToTop]
+other = "Vissza a tetejére"
+
 [themeSwitcher]
 other = "Téma váltása"
 

--- a/i18n/id.toml
+++ b/i18n/id.toml
@@ -63,6 +63,9 @@ other = "Ditemukan {{ .Count }} hasil dari “{{ .Term }}”"
 [searchResultsNone]
 other = "Tidak ditemukan hasil dari “{{ .Term }}”"
 
+[backToTop]
+other = "Kembali ke atas"
+
 [themeSwitcher]
 other = "Ganti tema"
 

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -63,6 +63,9 @@ other = "“{{ .Term }}” の検索結果が {{ .Count }} 件見つかりまし
 [searchResultsNone]
 other = "“{{ .Term }}” の検索結果が見つかりませんでした"
 
+[backToTop]
+other = "トップに戻る"
+
 [themeSwitcher]
 other = "テーマを切り替え"
 

--- a/i18n/ms.toml
+++ b/i18n/ms.toml
@@ -63,6 +63,9 @@ other = "Jumpa {{ .Count }} halaman untuk “{{ .Term }}”"
 [searchResultsNone]
 other = "Tidak jumpa sebarang halaman untuk “{{ .Term }}”"
 
+[backToTop]
+other = "Kembali ke atas"
+
 [themeSwitcher]
 other = "Tukar tema"
 

--- a/i18n/no.toml
+++ b/i18n/no.toml
@@ -63,6 +63,9 @@ other = "Fant {{ .Count }} resultater for “{{ .Term }}”"
 [searchResultsNone]
 other = "Ingen er funnet for “{{ .Term }}”"
 
+[backToTop]
+other = "Tilbake til toppen"
+
 [themeSwitcher]
 other = "Bytt tema"
 

--- a/i18n/pl.toml
+++ b/i18n/pl.toml
@@ -63,6 +63,9 @@ other = "Znaleziono {{ .Count }} wyniki/ów dla: “{{ .Term }}”"
 [searchResultsNone]
 other = "Brak wyników dla: “{{ .Term }}”"
 
+[backToTop]
+other = "Powrót do góry"
+
 [themeSwitcher]
 other = "Przełącz motyw"
 

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -63,6 +63,9 @@ other = "Encontrados {{ .Count }} resultados para “{{ .Term }}”"
 [searchResultsNone]
 other = "Não foram encontrados resultados para “{{ .Term }}”"
 
+[backToTop]
+other = "Voltar ao topo"
+
 [themeSwitcher]
 other = "Alternar tema"
 

--- a/i18n/ru.toml
+++ b/i18n/ru.toml
@@ -63,6 +63,9 @@ other = "Найдено {{ .Count }} результатов для “{{ .Term }
 [searchResultsNone]
 other = "Ничего не найдено для “{{ .Term }}”"
 
+[backToTop]
+other = "Вернуться наверх"
+
 [themeSwitcher]
 other = "Переключить тему"
 

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -63,6 +63,9 @@ other = "找到 {{ .Count }} 条关于「{{ .Term }}」的结果"
 [searchResultsNone]
 other = "没有找到关于「{{ .Term }}」的结果"
 
+[backToTop]
+other = "回到顶部"
+
 [themeSwitcher]
 other = "切换主题"
 

--- a/i18n/zh-hans.toml
+++ b/i18n/zh-hans.toml
@@ -65,6 +65,9 @@ other = "找到 {{ .Count }} 条关于「{{ .Term }}」的结果"
 [searchResultsNone]
 other = "没有找到关于「{{ .Term }}」的结果"
 
+[backToTop]
+other = "回到顶部"
+
 [themeSwitcher]
 other = "切换主题"
 

--- a/i18n/zh-hant.toml
+++ b/i18n/zh-hant.toml
@@ -65,6 +65,9 @@ other = "找到 {{ .Count }} 條關於「{{ .Term }}」的結果"
 [searchResultsNone]
 other = "沒有找到關於「{{ .Term }}」的結果"
 
+[backToTop]
+other = "回到頂部"
+
 [themeSwitcher]
 other = "切換主題"
 

--- a/i18n/zh-tw.toml
+++ b/i18n/zh-tw.toml
@@ -63,6 +63,9 @@ other = "找到 {{ .Count }} 條關於「{{ .Term }}」的結果"
 [searchResultsNone]
 other = "沒有找到關於「{{ .Term }}」的結果"
 
+[backToTop]
+other = "回到頂部"
+
 [themeSwitcher]
 other = "切換主題"
 

--- a/layouts/partials/components/back-to-top.html
+++ b/layouts/partials/components/back-to-top.html
@@ -1,5 +1,7 @@
 {{ if or (and .IsHome .Site.Params.displayBackToTopInHome) (and (not .IsHome) .Site.Params.enableBackToTop) }}
     <div id="back-to-top" class="back-to-top">
-        <a href="#">{{ partial "utils/icon.html" (dict "$" . "name" .Site.Params.backToTopIcon) }}</a>
+        <a href="#top" aria-label="{{ i18n "backToTop" }}">
+            {{ partial "utils/icon.html" (dict "$" . "name" .Site.Params.backToTopIcon) }}
+        </a>
     </div>
 {{ end }}


### PR DESCRIPTION
Also with i18n support. The homepage now achieves a Lighthouse score of 100 with this update.