### PR TITLE
feat: add native reading progress bar with toggle

### DIFF
--- a/assets/js/reading-progress.js
+++ b/assets/js/reading-progress.js
@@ -1,0 +1,23 @@
+const updateReadingProgress = () => {
+  const progressBar = document.querySelector("#reading-progress");
+
+  if (!progressBar) {
+    return;
+  }
+
+  const scrollHeight =
+    document.documentElement.scrollHeight - document.documentElement.clientHeight;
+
+  if (scrollHeight <= 0) {
+    progressBar.style.width = "0%";
+    return;
+  }
+
+  const scrollPercent = (window.scrollY / scrollHeight) * 100;
+  progressBar.style.width = `${scrollPercent}%`;
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.addEventListener("scroll", updateReadingProgress);
+  updateReadingProgress();
+});

--- a/assets/scss/components/_reading-progress.scss
+++ b/assets/scss/components/_reading-progress.scss
@@ -1,0 +1,10 @@
+#reading-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 4;
+    width: 0;
+    height: 2px;
+    background-color: var(--color-primary);
+    transition: width $duration;
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -382,6 +382,10 @@ $baseRelURL: "{{ "" | relURL | strings.TrimSuffix "/" }}";
     @import "components/socials";
 {{ end }}
 
+{{ if (.Site.Params.enableReadingProgress | default true) }}
+    @import "components/reading-progress";
+{{ end }}
+
 
 // Homepage Layout
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,9 @@
 <html lang="{{ .Site.LanguageCode }}"{{ if and .Site.Params.enableDarkMode .Site.Params.overrideSystemPreferences }}{{ with .Site.Params.defaultTheme | default "light" }} data-theme="{{ . }}"{{ end }}{{ end }}>
     {{ partial "head.html" . }}
     <body>
+        {{ if (.Site.Params.enableReadingProgress | default true) }}
+            <div id="reading-progress"></div>
+        {{ end }}
         <div class="container">
             {{ partial "header.html" . }}
             {{ if ne .Site.Params.headerLayout "flex" }}

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -40,6 +40,10 @@
     {{- $scripts = union $scripts (partial "third-party/algolia-search.html" .) -}}
 {{- end -}}
 
+{{- if (.Site.Params.enableReadingProgress | default true) -}}
+    {{- $scripts = union $scripts (slice "js/reading-progress.js") -}}
+{{- end -}}
+
 {{- $scripts = union $scripts (slice "js/custom.js") -}}
 
 {{- $processedScripts := slice ("" | resources.FromString "dummy.js") -}}


### PR DESCRIPTION
## Summary
- add a native reading progress bar element in `baseof.html`, controlled by `enableReadingProgress` (default: enabled)
- add `assets/js/reading-progress.js` and wire it into the existing script pipeline
- add `assets/scss/components/_reading-progress.scss` and conditionally import it in `main.scss`
- ensure compatibility with existing header layouts (`headerLayout = flex`) and auto-hide header behavior

## Why
Currently, reading progress behavior depends on site-level custom JS and is not provided natively by the theme. This PR brings the feature into the theme itself, with a parameterized toggle and sensible default behavior.

## Validation
- Hugo build succeeds with `hugo --minify`
- progress bar renders at the top and updates on scroll
- when `enableReadingProgress: false`, the DOM/CSS/JS are not injected

🤖 Generated with [Claude Code](https://claude.com/claude-code)