### PR TITLE
feat: add configurable Pagefind search integration

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,0 +1,45 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const normalizedPath = `${window.location.pathname.replace(/\/+$/, "")}/`
+  if (normalizedPath !== "/search/") {
+    return
+  }
+
+  const searchContainer = document.getElementById("search")
+  const statusNode = document.getElementById("search-status")
+
+  if (!searchContainer) {
+    return
+  }
+
+  if (typeof window.PagefindUI !== "function") {
+    if (statusNode) {
+      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+    }
+    return
+  }
+
+  try {
+    new window.PagefindUI({
+      element: "#search"
+    })
+
+    const input = searchContainer.querySelector('input[type="search"], input[type="text"]')
+    if (input) {
+      if (!input.id) {
+        input.id = "search-input"
+      }
+      if (!input.getAttribute("aria-label")) {
+        input.setAttribute("aria-label", "站内搜索输入框")
+      }
+    }
+
+    if (statusNode) {
+      statusNode.textContent = "请输入关键词开始搜索。"
+    }
+  } catch (error) {
+    if (statusNode) {
+      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+    }
+    console.error("[search] Pagefind 初始化失败", error)
+  }
+}, { once: true })

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,6 +1,14 @@
 window.addEventListener("DOMContentLoaded", () => {
+  const pagefindEnabled = {{ .Site.Params.enablePagefindSearch | default false }}
+  if (!pagefindEnabled) {
+    return
+  }
+
+  const searchPath = "{{ .Site.Params.pagefindSearchPath | default "/search/" }}"
   const normalizedPath = `${window.location.pathname.replace(/\/+$/, "")}/`
-  if (normalizedPath !== "/search/") {
+  const normalizedSearchPath = `${searchPath.replace(/\/+$/, "")}/`
+
+  if (normalizedPath !== normalizedSearchPath) {
     return
   }
 
@@ -13,7 +21,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   if (typeof window.PagefindUI !== "function") {
     if (statusNode) {
-      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+      statusNode.textContent = "{{ i18n "pagefindSearchUnavailable" }}"
     }
     return
   }
@@ -29,17 +37,17 @@ window.addEventListener("DOMContentLoaded", () => {
         input.id = "search-input"
       }
       if (!input.getAttribute("aria-label")) {
-        input.setAttribute("aria-label", "站内搜索输入框")
+        input.setAttribute("aria-label", "{{ i18n "pagefindSearchInputLabel" }}")
       }
     }
 
     if (statusNode) {
-      statusNode.textContent = "请输入关键词开始搜索。"
+      statusNode.textContent = "{{ i18n "pagefindSearchHint" }}"
     }
   } catch (error) {
     if (statusNode) {
-      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+      statusNode.textContent = "{{ i18n "pagefindSearchUnavailable" }}"
     }
-    console.error("[search] Pagefind 初始化失败", error)
+    console.error("[search] Pagefind initialization failed", error)
   }
 }, { once: true })

--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -1473,6 +1473,18 @@ uglyURLs = false
 
 
     ######################################
+    # Pagefind search
+
+    # Note: This feature provides a static
+    #       search page powered by Pagefind.
+    #       Generate index after Hugo build:
+    #       pagefind --site public
+
+    enablePagefindSearch = false
+    pagefindSearchPath = "/search/"
+
+
+    ######################################
     # 404 Page
 
     fofPoster = ""

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -1434,6 +1434,17 @@ uglyURLs = false
 
 
     ######################################
+    # Pagefind 搜索
+
+    # 说明：提供由 Pagefind 驱动的静态搜索页。
+    #      需要在 Hugo 构建后额外执行：
+    #      pagefind --site public
+
+    enablePagefindSearch = false
+    pagefindSearchPath = "/search/"
+
+
+    ######################################
     # 404 页面
 
     # 视频封面

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -68,6 +68,23 @@ other = "Back to top"
 
 [themeSwitcher]
 other = "Switch theme"
+[pagefindSearchHint]
+other = "Type keywords to search this site."
+
+[pagefindSearchRegionLabel]
+other = "Site search"
+
+[pagefindSearchLoading]
+other = "Loading search component..."
+
+[pagefindSearchNoScript]
+other = "Search requires JavaScript to be enabled."
+
+[pagefindSearchUnavailable]
+other = "Search is temporarily unavailable. Please try again later."
+
+[pagefindSearchInputLabel]
+other = "Search input"
 
 
 # Socials

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -68,6 +68,23 @@ other = "回到顶部"
 
 [themeSwitcher]
 other = "切换主题"
+[pagefindSearchHint]
+other = "请输入关键词开始搜索。"
+
+[pagefindSearchRegionLabel]
+other = "站内搜索区域"
+
+[pagefindSearchLoading]
+other = "正在加载搜索组件..."
+
+[pagefindSearchNoScript]
+other = "搜索需要启用 JavaScript。"
+
+[pagefindSearchUnavailable]
+other = "搜索暂不可用，请稍后再试。"
+
+[pagefindSearchInputLabel]
+other = "站内搜索输入框"
 
 
 # Socials

--- a/layouts/search/list.html
+++ b/layouts/search/list.html
@@ -3,13 +3,13 @@
     <div class="main-inner">
       <div class="content list-group">
         <h1 class="list-title">{{ .Title }}</h1>
-        <p>在下方输入关键词进行站内搜索。</p>
+        <p>{{ i18n "pagefindSearchHint" }}</p>
 
-        <section aria-label="站内搜索区域">
-          <div id="search" role="search" aria-label="站内搜索"></div>
-          <p id="search-status" role="status" aria-live="polite">正在加载搜索组件...</p>
+        <section aria-label="{{ i18n "pagefindSearchRegionLabel" }}">
+          <div id="search" role="search" aria-label="{{ i18n "pagefindSearchRegionLabel" }}"></div>
+          <p id="search-status" role="status" aria-live="polite">{{ i18n "pagefindSearchLoading" }}</p>
           <noscript>
-            <p>搜索需要启用 JavaScript。</p>
+            <p>{{ i18n "pagefindSearchNoScript" }}</p>
           </noscript>
         </section>
       </div>

--- a/layouts/search/list.html
+++ b/layouts/search/list.html
@@ -1,0 +1,21 @@
+{{ define "main" }}
+  <main class="main list" id="main">
+    <div class="main-inner">
+      <div class="content list-group">
+        <h1 class="list-title">{{ .Title }}</h1>
+        <p>在下方输入关键词进行站内搜索。</p>
+
+        <section aria-label="站内搜索区域">
+          <div id="search" role="search" aria-label="站内搜索"></div>
+          <p id="search-status" role="status" aria-live="polite">正在加载搜索组件...</p>
+          <noscript>
+            <p>搜索需要启用 JavaScript。</p>
+          </noscript>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}" />
+  <script defer src="{{ "pagefind/pagefind-ui.js" | relURL }}"></script>
+{{ end }}


### PR DESCRIPTION
## Summary
- add a dedicated `layouts/search/list.html` template for a Pagefind-powered search page
- make Pagefind behavior configurable with `enablePagefindSearch` and `pagefindSearchPath`
- internationalize search UI/status copy and add config examples in English and Simplified Chinese

## Test plan
- [x] Build Hugo site (`hugo --minify`) with this theme
- [x] Generate Pagefind index (`pagefind --site public`) after Hugo build
- [x] Verify `/search/` renders search container and status text
- [x] Verify search initialization only runs when `enablePagefindSearch = true`
- [x] Verify fallback status text is shown when `PagefindUI` is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)