### PR TITLE
feat: add configurable Pagefind search integration

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,4 +1,4 @@
-window.addEventListener("DOMContentLoaded", () => {
+window.addEventListener("DOMContentLoaded", async () => {
   const pagefindEnabled = {{ .Site.Params.enablePagefindSearch | default false }}
   if (!pagefindEnabled) {
     return
@@ -19,7 +19,23 @@ window.addEventListener("DOMContentLoaded", () => {
     return
   }
 
-  if (typeof window.PagefindUI !== "function") {
+  const waitForPagefindUI = async () => {
+    const timeoutMs = 2000
+    const intervalMs = 50
+    const maxTries = Math.ceil(timeoutMs / intervalMs)
+
+    for (let i = 0; i < maxTries; i++) {
+      if (typeof window.PagefindUI === "function") {
+        return true
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs))
+    }
+
+    return false
+  }
+
+  const pagefindReady = await waitForPagefindUI()
+  if (!pagefindReady) {
     if (statusNode) {
       statusNode.textContent = "{{ i18n "pagefindSearchUnavailable" }}"
     }

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,0 +1,45 @@
+window.addEventListener("DOMContentLoaded", () => {
+  const normalizedPath = `${window.location.pathname.replace(/\/+$/, "")}/`
+  if (normalizedPath !== "/search/") {
+    return
+  }
+
+  const searchContainer = document.getElementById("search")
+  const statusNode = document.getElementById("search-status")
+
+  if (!searchContainer) {
+    return
+  }
+
+  if (typeof window.PagefindUI !== "function") {
+    if (statusNode) {
+      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+    }
+    return
+  }
+
+  try {
+    new window.PagefindUI({
+      element: "#search"
+    })
+
+    const input = searchContainer.querySelector('input[type="search"], input[type="text"]')
+    if (input) {
+      if (!input.id) {
+        input.id = "search-input"
+      }
+      if (!input.getAttribute("aria-label")) {
+        input.setAttribute("aria-label", "站内搜索输入框")
+      }
+    }
+
+    if (statusNode) {
+      statusNode.textContent = "请输入关键词开始搜索。"
+    }
+  } catch (error) {
+    if (statusNode) {
+      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+    }
+    console.error("[search] Pagefind 初始化失败", error)
+  }
+}, { once: true })

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,6 +1,14 @@
 window.addEventListener("DOMContentLoaded", () => {
+  const pagefindEnabled = {{ .Site.Params.enablePagefindSearch | default false }}
+  if (!pagefindEnabled) {
+    return
+  }
+
+  const searchPath = "{{ .Site.Params.pagefindSearchPath | default "/search/" }}"
   const normalizedPath = `${window.location.pathname.replace(/\/+$/, "")}/`
-  if (normalizedPath !== "/search/") {
+  const normalizedSearchPath = `${searchPath.replace(/\/+$/, "")}/`
+
+  if (normalizedPath !== normalizedSearchPath) {
     return
   }
 
@@ -13,7 +21,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   if (typeof window.PagefindUI !== "function") {
     if (statusNode) {
-      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+      statusNode.textContent = "{{ i18n "pagefindSearchUnavailable" }}"
     }
     return
   }
@@ -29,17 +37,17 @@ window.addEventListener("DOMContentLoaded", () => {
         input.id = "search-input"
       }
       if (!input.getAttribute("aria-label")) {
-        input.setAttribute("aria-label", "站内搜索输入框")
+        input.setAttribute("aria-label", "{{ i18n "pagefindSearchInputLabel" }}")
       }
     }
 
     if (statusNode) {
-      statusNode.textContent = "请输入关键词开始搜索。"
+      statusNode.textContent = "{{ i18n "pagefindSearchHint" }}"
     }
   } catch (error) {
     if (statusNode) {
-      statusNode.textContent = "搜索暂不可用，请稍后再试。"
+      statusNode.textContent = "{{ i18n "pagefindSearchUnavailable" }}"
     }
-    console.error("[search] Pagefind 初始化失败", error)
+    console.error("[search] Pagefind initialization failed", error)
   }
 }, { once: true })

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -58,7 +58,7 @@ window.addEventListener("DOMContentLoaded", async () => {
     }
 
     if (statusNode) {
-      statusNode.textContent = "{{ i18n "pagefindSearchHint" }}"
+      statusNode.textContent = ""
     }
   } catch (error) {
     if (statusNode) {

--- a/assets/scss/layout/_single.scss
+++ b/assets/scss/layout/_single.scss
@@ -103,16 +103,45 @@ blockquote {
 }
 
 .contents {
-    margin-top: 5em;
+    margin-top: 4em;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-contrast-lower);
+    border-radius: 0.5rem;
+
+    .contents-title {
+        margin: 0 0 0.75rem;
+    }
+
     ol, ul {
         list-style: none;
+        margin: 0;
+        padding-left: 1.25rem;
+    }
+
+    a {
+        text-decoration: none;
+        color: var(--color-contrast-high);
+
+        &:hover {
+            color: var(--color-primary);
+            text-decoration: underline;
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--color-primary);
+            outline-offset: 2px;
+            border-radius: 0.2rem;
+        }
     }
 }
 ol, ul {
     &.toc {
         padding: 0;
-        overflow: auto hidden;
-        white-space: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
     }
 }
 

--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -1473,6 +1473,18 @@ uglyURLs = false
 
 
     ######################################
+    # Pagefind search
+
+    # Note: This feature provides a static
+    #       search page powered by Pagefind.
+    #       Generate index after Hugo build:
+    #       pagefind --site public
+
+    enablePagefindSearch = false
+    pagefindSearchPath = "/search/"
+
+
+    ######################################
     # 404 Page
 
     fofPoster = ""

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -1434,6 +1434,17 @@ uglyURLs = false
 
 
     ######################################
+    # Pagefind 搜索
+
+    # 说明：提供由 Pagefind 驱动的静态搜索页。
+    #      需要在 Hugo 构建后额外执行：
+    #      pagefind --site public
+
+    enablePagefindSearch = false
+    pagefindSearchPath = "/search/"
+
+
+    ######################################
     # 404 页面
 
     # 视频封面

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -68,6 +68,23 @@ other = "Back to top"
 
 [themeSwitcher]
 other = "Switch theme"
+[pagefindSearchHint]
+other = "Type keywords to search this site."
+
+[pagefindSearchRegionLabel]
+other = "Site search"
+
+[pagefindSearchLoading]
+other = "Loading search component..."
+
+[pagefindSearchNoScript]
+other = "Search requires JavaScript to be enabled."
+
+[pagefindSearchUnavailable]
+other = "Search is temporarily unavailable. Please try again later."
+
+[pagefindSearchInputLabel]
+other = "Search input"
 
 
 # Socials

--- a/i18n/zh-cn.toml
+++ b/i18n/zh-cn.toml
@@ -68,6 +68,23 @@ other = "回到顶部"
 
 [themeSwitcher]
 other = "切换主题"
+[pagefindSearchHint]
+other = "请输入关键词开始搜索。"
+
+[pagefindSearchRegionLabel]
+other = "站内搜索区域"
+
+[pagefindSearchLoading]
+other = "正在加载搜索组件..."
+
+[pagefindSearchNoScript]
+other = "搜索需要启用 JavaScript。"
+
+[pagefindSearchUnavailable]
+other = "搜索暂不可用，请稍后再试。"
+
+[pagefindSearchInputLabel]
+other = "站内搜索输入框"
 
 
 # Socials

--- a/layouts/partials/utils/toc.html
+++ b/layouts/partials/utils/toc.html
@@ -1,27 +1,30 @@
 {{- $toc := .TableOfContents -}}
+{{- $hasTOCItems := gt (len (findRE `<li>` $toc)) 0 -}}
 
-<!-- Change TOC Attribute -->
-{{- $regexPatternTOC := `<nav id="TableOfContents">` -}}
-{{- $regexReplacementTOC := `<nav class="contents">` -}}
-{{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
-
-<!-- Inject Class Attribute -->
-{{- $regexPatternTOC := `(<nav class="contents">\n.+)<(ol|ul)>` -}}
-{{- $regexReplacementTOC := `$1<$2 class="toc">` -}}
-{{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
-
-<!-- Inject TOC Title -->
-{{- if .Site.Params.displayTOCTitle -}}
-    {{- $regexPatternTOC := `(<nav class="contents">\n.+)(<(ol|ul) class="toc">)` -}}
-    {{- $regexReplacementTOC := (printf `$1<h2 id="contents" class="contents-title">%s</h2>$2` (i18n "tocTitle")) -}}
+{{- if $hasTOCItems -}}
+    <!-- Change TOC Attribute -->
+    {{- $regexPatternTOC := `<nav id="TableOfContents">` -}}
+    {{- $regexReplacementTOC := `<nav class="contents">` -}}
     {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+
+    <!-- Inject Class Attribute (first list only, multiline-safe) -->
+    {{- $regexPatternTOC := `(?s)(<nav class="contents">.*?)(<(ol|ul)>)` -}}
+    {{- $regexReplacementTOC := `$1<$3 class="toc">` -}}
+    {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+
+    <!-- Inject TOC Title -->
+    {{- if .Site.Params.displayTOCTitle -}}
+        {{- $regexPatternTOC := `(?s)(<nav class="contents">)(\s*<(ol|ul) class="toc">)` -}}
+        {{- $regexReplacementTOC := (printf `$1<h2 id="contents" class="contents-title">%s</h2>$2` (i18n "tocTitle")) -}}
+        {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+    {{- end -}}
+
+    <!-- Link Headings to TOC -->
+    {{- if .Site.Params.linkHeadingsToTOC -}}
+        {{- $regexPatternTOC := `(<a)( href="#([^"]+)">)` -}}
+        {{- $regexReplacementTOC := `$1 id="contents:$3"$2` -}}
+        {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+    {{ end }}
+
+    {{- $toc | safeHTML -}}
 {{- end -}}
-
-<!-- Link Headings to TOC -->
-{{- if .Site.Params.linkHeadingsToTOC -}}
-    {{- $regexPatternTOC := `(<a)( href="#([^"]+)">)` -}}
-    {{- $regexReplacementTOC := `$1 id="contents:$3"$2` -}}
-    {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
-{{ end }}
-
-{{- $toc | safeHTML -}}

--- a/layouts/search/list.html
+++ b/layouts/search/list.html
@@ -3,13 +3,13 @@
     <div class="main-inner">
       <div class="content list-group">
         <h1 class="list-title">{{ .Title }}</h1>
-        <p>在下方输入关键词进行站内搜索。</p>
+        <p>{{ i18n "pagefindSearchHint" }}</p>
 
-        <section aria-label="站内搜索区域">
-          <div id="search" role="search" aria-label="站内搜索"></div>
-          <p id="search-status" role="status" aria-live="polite">正在加载搜索组件...</p>
+        <section aria-label="{{ i18n "pagefindSearchRegionLabel" }}">
+          <div id="search" role="search" aria-label="{{ i18n "pagefindSearchRegionLabel" }}"></div>
+          <p id="search-status" role="status" aria-live="polite">{{ i18n "pagefindSearchLoading" }}</p>
           <noscript>
-            <p>搜索需要启用 JavaScript。</p>
+            <p>{{ i18n "pagefindSearchNoScript" }}</p>
           </noscript>
         </section>
       </div>

--- a/layouts/search/list.html
+++ b/layouts/search/list.html
@@ -3,7 +3,6 @@
     <div class="main-inner">
       <div class="content list-group">
         <h1 class="list-title">{{ .Title }}</h1>
-        <p>{{ i18n "pagefindSearchHint" }}</p>
 
         <section aria-label="{{ i18n "pagefindSearchRegionLabel" }}">
           <div id="search" role="search" aria-label="{{ i18n "pagefindSearchRegionLabel" }}"></div>

--- a/layouts/search/list.html
+++ b/layouts/search/list.html
@@ -17,5 +17,5 @@
   </main>
 
   <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}" />
-  <script defer src="{{ "pagefind/pagefind-ui.js" | relURL }}"></script>
+  <script data-cfasync="false" defer src="{{ "pagefind/pagefind-ui.js" | relURL }}"></script>
 {{ end }}

--- a/layouts/search/list.html
+++ b/layouts/search/list.html
@@ -1,0 +1,21 @@
+{{ define "main" }}
+  <main class="main list" id="main">
+    <div class="main-inner">
+      <div class="content list-group">
+        <h1 class="list-title">{{ .Title }}</h1>
+        <p>在下方输入关键词进行站内搜索。</p>
+
+        <section aria-label="站内搜索区域">
+          <div id="search" role="search" aria-label="站内搜索"></div>
+          <p id="search-status" role="status" aria-live="polite">正在加载搜索组件...</p>
+          <noscript>
+            <p>搜索需要启用 JavaScript。</p>
+          </noscript>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}" />
+  <script defer src="{{ "pagefind/pagefind-ui.js" | relURL }}"></script>
+{{ end }}


### PR DESCRIPTION
## Summary
- add a dedicated `layouts/search/list.html` template for a Pagefind-powered search page
- make Pagefind behavior configurable with `enablePagefindSearch` and `pagefindSearchPath`
- internationalize search UI/status copy and add config examples in English and Simplified Chinese

## Test plan
- [x] Build Hugo site (`hugo --minify`) with this theme
- [x] Generate Pagefind index (`pagefind --site public`) after Hugo build
- [x] Verify `/search/` renders search container and status text
- [x] Verify search initialization only runs when `enablePagefindSearch = true`
- [x] Verify fallback status text is shown when `PagefindUI` is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)