### PR TITLE
fix(toc): improve TOC rendering robustness and readability

### DIFF
--- a/assets/scss/layout/_single.scss
+++ b/assets/scss/layout/_single.scss
@@ -103,16 +103,45 @@ blockquote {
 }
 
 .contents {
-    margin-top: 5em;
+    margin-top: 4em;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--color-contrast-lower);
+    border-radius: 0.5rem;
+
+    .contents-title {
+        margin: 0 0 0.75rem;
+    }
+
     ol, ul {
         list-style: none;
+        margin: 0;
+        padding-left: 1.25rem;
+    }
+
+    a {
+        text-decoration: none;
+        color: var(--color-contrast-high);
+
+        &:hover {
+            color: var(--color-primary);
+            text-decoration: underline;
+        }
+
+        &:focus-visible {
+            outline: 2px solid var(--color-primary);
+            outline-offset: 2px;
+            border-radius: 0.2rem;
+        }
     }
 }
 ol, ul {
     &.toc {
         padding: 0;
-        overflow: auto hidden;
-        white-space: nowrap;
+        overflow-x: auto;
+        overflow-y: hidden;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: break-word;
     }
 }
 

--- a/layouts/partials/utils/toc.html
+++ b/layouts/partials/utils/toc.html
@@ -1,27 +1,30 @@
 {{- $toc := .TableOfContents -}}
+{{- $hasTOCItems := gt (len (findRE `<li>` $toc)) 0 -}}
 
-<!-- Change TOC Attribute -->
-{{- $regexPatternTOC := `<nav id="TableOfContents">` -}}
-{{- $regexReplacementTOC := `<nav class="contents">` -}}
-{{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
-
-<!-- Inject Class Attribute -->
-{{- $regexPatternTOC := `(<nav class="contents">\n.+)<(ol|ul)>` -}}
-{{- $regexReplacementTOC := `$1<$2 class="toc">` -}}
-{{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
-
-<!-- Inject TOC Title -->
-{{- if .Site.Params.displayTOCTitle -}}
-    {{- $regexPatternTOC := `(<nav class="contents">\n.+)(<(ol|ul) class="toc">)` -}}
-    {{- $regexReplacementTOC := (printf `$1<h2 id="contents" class="contents-title">%s</h2>$2` (i18n "tocTitle")) -}}
+{{- if $hasTOCItems -}}
+    <!-- Change TOC Attribute -->
+    {{- $regexPatternTOC := `<nav id="TableOfContents">` -}}
+    {{- $regexReplacementTOC := `<nav class="contents">` -}}
     {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+
+    <!-- Inject Class Attribute (first list only, multiline-safe) -->
+    {{- $regexPatternTOC := `(?s)(<nav class="contents">.*?)(<(ol|ul)>)` -}}
+    {{- $regexReplacementTOC := `$1<$3 class="toc">` -}}
+    {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+
+    <!-- Inject TOC Title -->
+    {{- if .Site.Params.displayTOCTitle -}}
+        {{- $regexPatternTOC := `(?s)(<nav class="contents">)(\s*<(ol|ul) class="toc">)` -}}
+        {{- $regexReplacementTOC := (printf `$1<h2 id="contents" class="contents-title">%s</h2>$2` (i18n "tocTitle")) -}}
+        {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+    {{- end -}}
+
+    <!-- Link Headings to TOC -->
+    {{- if .Site.Params.linkHeadingsToTOC -}}
+        {{- $regexPatternTOC := `(<a)( href="#([^"]+)">)` -}}
+        {{- $regexReplacementTOC := `$1 id="contents:$3"$2` -}}
+        {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
+    {{ end }}
+
+    {{- $toc | safeHTML -}}
 {{- end -}}
-
-<!-- Link Headings to TOC -->
-{{- if .Site.Params.linkHeadingsToTOC -}}
-    {{- $regexPatternTOC := `(<a)( href="#([^"]+)">)` -}}
-    {{- $regexReplacementTOC := `$1 id="contents:$3"$2` -}}
-    {{- $toc = $toc | replaceRE $regexPatternTOC $regexReplacementTOC -}}
-{{ end }}
-
-{{- $toc | safeHTML -}}


### PR DESCRIPTION
## Summary
- Improve TOC markup transformation to be multiline-safe and less sensitive to exact newline formatting.
- Avoid rendering an empty TOC container when no TOC list items exist.
- Enhance TOC readability and accessibility in single pages:
  - better spacing and visual container
  - link hover/contrast improvements
  - visible keyboard focus (`:focus-visible`)
  - allow long TOC entries to wrap instead of forced single-line overflow

## Why
Some pages with TOC enabled but without effective heading items could still render an empty TOC box. Also, previous TOC regex transformations relied on strict newline patterns, which is brittle across formatting changes. This patch keeps behavior compatible while making TOC rendering and UX more robust.

## Test plan
- [x] Build theme-integrated site successfully.
- [x] Verify pages with heading-based TOC render correctly.
- [x] Verify pages without TOC items no longer render an empty TOC container.
- [x] Verify keyboard tab focus is visible on TOC links.
- [x] Verify long TOC entries wrap without layout breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)