### PR TITLE
fix: replace APIs deprecated in Hugo v0.158.0 / v0.156.0

### DIFF
--- a/config-examples/en/config.toml
+++ b/config-examples/en/config.toml
@@ -3,7 +3,7 @@
 
 baseURL = "https://example.com/"
 title = "Hugo Theme MemE"
-languageCode = "en"
+locale = "en"
 hasCJKLanguage = false
 # Copyright information (Markdown supported)
 copyright = "[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en)"

--- a/config-examples/zh-cn/config.toml
+++ b/config-examples/zh-cn/config.toml
@@ -3,7 +3,7 @@
 
 baseURL = "https://example.com/"
 title = "Hugo 主题 MemE"
-languageCode = "zh-CN"
+locale = "zh-CN"
 hasCJKLanguage = true
 # 版权信息（支持 Markdown）
 copyright = "[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh)"

--- a/config-examples/zh-tw/config.toml
+++ b/config-examples/zh-tw/config.toml
@@ -3,7 +3,7 @@
 
 baseURL = "https://example.com/"
 title = "Hugo 主題 MemE"
-languageCode = "zh-TW"
+locale = "zh-TW"
 hasCJKLanguage = true
 # 版權資訊（支援 Markdown）
 copyright = "[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.zh)"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
     {{ partial "head.html" . }}
     <body>
         <div class="container">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}"{{ if and .Site.Params.enableDarkMode .Site.Params.overrideSystemPreferences }}{{ with .Site.Params.defaultTheme | default "light" }} data-theme="{{ . }}"{{ end }}{{ end }}>
+<html lang="{{ .Site.Language.Locale }}"{{ if and .Site.Params.enableDarkMode .Site.Params.overrideSystemPreferences }}{{ with .Site.Params.defaultTheme | default "light" }} data-theme="{{ . }}"{{ end }}{{ end }}>
     {{ partial "head.html" . }}
     <body>
         <div class="container">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -53,7 +53,7 @@
                     {{ range $pages.GroupByDate "2006" }}
                         {{ $.Scratch.Delete "zodiacName" }}
                         {{ if $.Site.Params.chineseZodiac }}
-                            {{ $zodiacName := (index $.Site.Data.ChineseZodiac (string (mod .Key 12))) }}
+                            {{ $zodiacName := (index hugo.Data.ChineseZodiac (string (mod .Key 12))) }}
                             {{ $.Scratch.Set "zodiacName" $zodiacName }}
                         {{ end }}
                         {{ $zodiacName := $.Scratch.Get "zodiacName" }}

--- a/layouts/index.sectionsatom.xml
+++ b/layouts/index.sectionsatom.xml
@@ -7,7 +7,7 @@
 {{- if ge $limit 1 -}}
     {{- $pages = $pages | first $limit -}}
 {{- end -}}
-<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ .Site.LanguageCode }}">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="{{ .Site.Language.Locale }}">
     <title type="text">{{ .Site.Title }}</title>
     <subtitle type="html">{{ .Site.Params.siteDescription }}</subtitle>
     <updated>{{ now.Format "2006-01-02T15:04:05-07:00" }}</updated>

--- a/layouts/index.sectionsrss.xml
+++ b/layouts/index.sectionsrss.xml
@@ -16,7 +16,7 @@
         <link>{{ .Permalink }}</link>
         <description>{{ .Site.Params.siteDescription }}</description>
         <generator>Hugo {{ hugo.Version }} https://gohugo.io/</generator>
-        {{ with .Site.LanguageCode }}
+        {{ with .Site.Language.Locale }}
             <language>{{ . }}</language>
         {{ end }}
         {{ with .Site.Params.author.email }}

--- a/layouts/partials/components/fedishare.html
+++ b/layouts/partials/components/fedishare.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
+<html lang="{{ .Site.Language.Locale }}">
     {{ .Scratch.Set "fedishare_page" true -}}
     {{ partial "head.html" . }}
     {{ .Scratch.Delete "fedishare_page" -}}

--- a/layouts/partials/components/minimal-footer-about.html
+++ b/layouts/partials/components/minimal-footer-about.html
@@ -6,7 +6,7 @@
                     {{ range $index, $value := . }}
                         {{- $linkType := (string .Pre) -}}
                         {{- $iconName := (string .Post) -}}
-                        {{- $icon := (index $.Site.Data.SVG $iconName) -}}
+                        {{- $icon := (index hugo.Data.SVG $iconName) -}}
                         <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "$" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{ end }}
                 </div>
@@ -16,7 +16,7 @@
                     {{ range $index, $value := . }}
                         {{- $linkType := (string .Pre) -}}
                         {{- $iconName := (string .Post) -}}
-                        {{- $icon := (index $.Site.Data.SVG $iconName) -}}
+                        {{- $icon := (index hugo.Data.SVG $iconName) -}}
                         <a href="{{ .URL }}"{{ if eq $linkType "external" }} target="_blank" rel="external noopener"{{ end }}>{{ partial "utils/icon.html" (dict "$" $ "name" $iconName "class" .Identifier) }}{{ .Name }}</a>
                     {{ end }}
                 </div>

--- a/layouts/partials/components/socials.html
+++ b/layouts/partials/components/socials.html
@@ -1,5 +1,5 @@
 {{ if .Site.Params.enableSocials }}
-    {{ with .Site.Data.Socials }}
+    {{ with hugo.Data.Socials }}
         <ul class="socials">
             {{- range sort .socials "weight" -}}
                 <li class="socials-item">

--- a/layouts/partials/utils/content.html
+++ b/layouts/partials/utils/content.html
@@ -18,7 +18,7 @@
     {{- $headings := $headings | default "1-6" -}}
 
     {{- with .Site.Params.anchorIcon -}}
-        {{- $icon := (replace (index $.Site.Data.SVG .) "icon" "icon anchor-icon") -}}
+        {{- $icon := (replace (index hugo.Data.SVG .) "icon" "icon anchor-icon") -}}
         {{- $.Scratch.Set "icon" $icon -}}
     {{- end -}}
     {{- $icon := .Scratch.Get "icon" -}}

--- a/layouts/partials/utils/icon.html
+++ b/layouts/partials/utils/icon.html
@@ -1,6 +1,6 @@
 {{- $ := index . "$" -}}
 {{- $name := .name -}}
 {{- $class := .class | default $name -}}
-{{- $icon := index $.Site.Data.SVG $name -}}
+{{- $icon := index hugo.Data.SVG $name -}}
 {{- $class := printf "icon %s" $class -}}
 {{- return (replace $icon "icon" $class | safeHTML) -}}

--- a/layouts/partials/utils/json-ld.html
+++ b/layouts/partials/utils/json-ld.html
@@ -61,7 +61,7 @@
         "url": {{ $.Permalink }},
         "headline": {{ $rawTitle }},
         "description": {{ $description }},
-        "inLanguage" : "{{ $.Site.LanguageCode }}",
+        "inLanguage" : "{{ $.Site.Language.Locale }}",
         "articleSection": {{ $.Section }},
         "wordCount": {{ $.WordCount }},
         {{ with $images -}}


### PR DESCRIPTION
## Summary
- Replace deprecated `.Site.LanguageCode` with `.Site.Language.Locale`
- Replace deprecated `.Site.Data` with `hugo.Data`
- Update example configs: `languageCode` → `locale`
- Fixes deprecation warnings reported in #504

## Test plan
- [x] `hugo` build of a site using this theme completes with no `.Site.LanguageCode` / `.Site.Data` warnings
- [ ] Confirm `lang` / `xml:lang` / JSON-LD `inLanguage` still render correctly
- [ ] Confirm SVG icons / socials / Chinese zodiac data still resolve via `hugo.Data`


Made with [Cursor](https://cursor.com)